### PR TITLE
GitHub Actions: CodeQL & Security Scan

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,9 +85,6 @@ jobs:
 
     - name: CodeQL – Initialize
       uses: github/codeql-action/init@v1
-      with:
-        languages: csharp
-        queries: security-extended,security-and-quality
 
     - name: CodeQL – Build
       uses: github/codeql-action/autobuild@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,3 +53,33 @@ jobs:
         path: ./.github
     - name: Markdown – Validate Links
       uses: gaurav-nelson/github-action-markdown-link-check@1.0.8
+
+    - name: Security Scan – Validate
+      uses: ShiftLeftSecurity/scan-action@v1.3.0
+      with:
+        type: credscan,depscan
+
+    - name: Security Scan – Upload Report
+      uses: github/codeql-action/upload-sarif@v1
+      with:
+        sarif_file: reports
+
+  validate-codeql:
+    name: Validate – CodeQL
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: CodeQL – Initialize
+      uses: github/codeql-action/init@v1
+      with:
+        languages: csharp
+        queries: security-extended,security-and-quality
+
+    - name: CodeQL – Build
+      uses: github/codeql-action/autobuild@v1
+
+    - name: CodeQL – Analyze
+      uses: github/codeql-action/analyze@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,6 +92,7 @@ jobs:
     - name: CodeQL – Initialize
       uses: github/codeql-action/init@v1
       with:
+        disable-default-queries: true
         queries: ${{ matrix.query }}
 
     - name: CodeQL – Build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,12 +79,18 @@ jobs:
     name: Validate – CodeQL
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        query: [security-extended, security-and-quality]
+
     steps:
     - name: Checkout
       uses: actions/checkout@v2
 
     - name: CodeQL – Initialize
       uses: github/codeql-action/init@v1
+      with:
+        queries: ${{ matrix.query }}
 
     - name: CodeQL – Build
       uses: github/codeql-action/autobuild@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,11 +80,6 @@ jobs:
     name: Validate – CodeQL
     runs-on: ubuntu-latest
 
-    strategy:
-      fail-fast: false
-      matrix:
-        query: [security-extended, security-and-quality]
-
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -92,8 +87,7 @@ jobs:
     - name: CodeQL – Initialize
       uses: github/codeql-action/init@v1
       with:
-        disable-default-queries: true
-        queries: ${{ matrix.query }}
+        queries: security-and-quality
 
     - name: CodeQL – Build
       uses: github/codeql-action/autobuild@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
         configuration: [Debug, Release]
 
@@ -80,6 +81,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
         query: [security-extended, security-and-quality]
 


### PR DESCRIPTION
# Pull Request

## Summary

Adding the following security validations to the build GitHub Action, to run on every commit and every PR:
- [CodeQL](https://securitylab.github.com/tools/codeql)
- [Security Scan](https://github.com/marketplace/actions/security-and-licence-scan)

CodeQL runs as a discrete job as it takes a relatively long time to run (approximately 10 minutes). In contrast, Security Scan runs in the existing validation job. This division helps to keep the overall running time down, while minimizing GitHub Action costs.

## Previous Behavior

No security validation was present.

## New Behavior

The build GitHub Action includes both CodeQL and Security Scan validations.

## Breaking Changes

The new validations will become required checks for merging a PR.

## Testing Undertaken

All GitHub Actions were run successfully after making this change.