### PR TITLE
Upgrading to .NET 5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,8 @@ jobs:
 
     - name: Install .NET
       uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '5.0.x'
 
     - name: Install NuGet Dependencies
       run: dotnet restore

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,6 +89,7 @@ jobs:
     - name: CodeQL – Initialize
       uses: github/codeql-action/init@v1
       with:
+        paths-ignore: '**/obj/**'
         queries: security-and-quality
 
     - name: CodeQL – Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,6 +61,8 @@ jobs:
 
     - name: Install .NET
       uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '5.0.x'
 
     - name: Install NuGet Dependencies
       run: >-

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -17,6 +17,7 @@
     <Nullable>enable</Nullable>
     <PackageLicenseFile>$(MSBuildThisFileDirectory)\..\LICENSE.md</PackageLicenseFile>
     <RepositoryUrl>https://github.com/muiriswoulfe/NuGet-Transitive-Dependency-Finder</RepositoryUrl>
+    <TargetFramework>net5.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <Version>1.0.0</Version>
   </PropertyGroup>

--- a/src/NuGet.TransitiveDependency.Finder.ConsoleApp/NuGet.TransitiveDependency.Finder.ConsoleApp.csproj
+++ b/src/NuGet.TransitiveDependency.Finder.ConsoleApp/NuGet.TransitiveDependency.Finder.ConsoleApp.csproj
@@ -5,7 +5,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <Product>NuGet Transitive Dependency Finder Console App</Product>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NuGet.TransitiveDependency.Finder.Library/NuGet.TransitiveDependency.Finder.Library.csproj
+++ b/src/NuGet.TransitiveDependency.Finder.Library/NuGet.TransitiveDependency.Finder.Library.csproj
@@ -5,7 +5,6 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <Product>NuGet Transitive Dependency Finder Library</Product>
-    <TargetFramework>netstandard2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NuGet.TransitiveDependency.Finder.Library/ProjectAnalysis/DotNetRunner.cs
+++ b/src/NuGet.TransitiveDependency.Finder.Library/ProjectAnalysis/DotNetRunner.cs
@@ -70,7 +70,7 @@ namespace NuGet.TransitiveDependency.Finder.Library.ProjectAnalysis
         /// <param name="sender">The event sender.</param>
         /// <param name="e">The event parameters.</param>
         private void LogError(object sender, DataReceivedEventArgs e) =>
-            this.logger.LogError(e.Data);
+            this.logger.LogError(e.Data ?? string.Empty);
 
         /// <summary>
         /// Logs messages sent to the Standard Output stream.
@@ -78,6 +78,6 @@ namespace NuGet.TransitiveDependency.Finder.Library.ProjectAnalysis
         /// <param name="sender">The event sender.</param>
         /// <param name="e">The event parameters.</param>
         private void LogOutput(object sender, DataReceivedEventArgs e) =>
-            this.logger.LogOutput(e.Data);
+            this.logger.LogOutput(e.Data ?? string.Empty);
     }
 }

--- a/src/global.json
+++ b/src/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "3.1.403",
+    "version": "5.0.100",
     "allowPrerelease": false,
     "rollForward": "latestPatch"
   }


### PR DESCRIPTION
# Pull Request

## Summary

Updating the project to the newly release .NET 5. This allows the latest libraries, performance enhancements, validation, and other improvements to be leveraged.

## Previous Behavior

The project used .NET Core 3.1 and .NET Standard 2.0.

## New Behavior

The project now uses .NET 5 throughout. There should be no behavioral changes resulting from this upgrade.

## Breaking Changes

There should be no breaking changes resulting from this upgrade.

## Testing Undertaken

The application was run under typical circumstances. No changes to functionality or behavior were detected.