### PR TITLE
Fixing CodeQL-identified issues

### DIFF
--- a/src/NuGet.TransitiveDependency.Finder.ConsoleApp/Output/Writer.cs
+++ b/src/NuGet.TransitiveDependency.Finder.ConsoleApp/Output/Writer.cs
@@ -5,7 +5,6 @@
 
 namespace NuGet.TransitiveDependency.Finder.ConsoleApp.Output
 {
-    using System;
     using Microsoft.Extensions.Logging;
     using NuGet.TransitiveDependency.Finder.ConsoleApp.Resources;
     using NuGet.TransitiveDependency.Finder.Library.Output;

--- a/src/NuGet.TransitiveDependency.Finder.ConsoleApp/Program.cs
+++ b/src/NuGet.TransitiveDependency.Finder.ConsoleApp/Program.cs
@@ -5,7 +5,6 @@
 
 namespace NuGet.TransitiveDependency.Finder.ConsoleApp
 {
-    using System;
     using Microsoft.Extensions.Logging;
     using Microsoft.Extensions.Logging.Console;
     using NuGet.TransitiveDependency.Finder.ConsoleApp.Output;

--- a/src/NuGet.TransitiveDependency.Finder.Library/ProjectAnalysis/Assets.cs
+++ b/src/NuGet.TransitiveDependency.Finder.Library/ProjectAnalysis/Assets.cs
@@ -10,7 +10,6 @@ namespace NuGet.TransitiveDependency.Finder.Library.ProjectAnalysis
     using NuGet.Common;
     using NuGet.ProjectModel;
     using static System.FormattableString;
-    using ILogger = Microsoft.Extensions.Logging.ILogger;
 
     /// <summary>
     /// A class representing the contents of a "project.assets.json" file.


### PR DESCRIPTION
# Pull Request

## Summary

This PR resolves some remaining CodeQL-identified issues around unused `using` directives.

## Previous Behavior

There were unused `using` directives in some files.

## New Behavior

There are now no unused `using` directives in any files.

## Breaking Changes

This change does not in any way affect functionality as the removed code was entirely unused.

## Testing Undertaken

The app was tested and behaved identically to before. In addition, no issues were detected during GitHub Action code scanning.