### PR TITLE
Updating gaurav-nelson/github-action-markdown-link-check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -133,7 +133,7 @@ jobs:
         config_file: .markdownlint.json
 
     - name: Markdown – Validate Links
-      uses: gaurav-nelson/github-action-markdown-link-check@1.0.10
+      uses: gaurav-nelson/github-action-markdown-link-check@1.0.11
 
     - name: Security Scan – Validate
       uses: ShiftLeftSecurity/scan-action@v1.3.0


### PR DESCRIPTION
# Pull Request

## Summary

Updating the `gaurav-nelson/github-action-markdown-link-check` GitHub Action from 1.0.10 to 1.0.11 to leverage the latest fixes.