### PR TITLE
Fixing Super-Linter Validation

### DIFF
--- a/.github/linters/.jscpd.json
+++ b/.github/linters/.jscpd.json
@@ -1,0 +1,3 @@
+{
+  "ignore": ["**/workflows/*.yml"]
+}


### PR DESCRIPTION
# Pull Request

## Summary

Following the addition of JSCPD to Super-Linter, validation has failed due to repetition within the `release.yml` GitHub Action definition. However, this repetition cannot be resolved due to the lack of facilities for avoiding duplication within GitHub Actions.

## Behavior

### Previous

The "Release" GitHub Action failed when linting `release.yml`.

### New

The "Release" GitHub Action no longer fails.

## Breaking Changes

No breaking changes.

## Testing Undertaken

This change was tested via the "Release" GitHub Action, which passed successfully.

## Additional Information

Information on JSCPD configuration can be found at <https://github.com/kucherenko/jscpd/tree/master/packages/jscpd>, while information on Super-Linter can be found at <https://github.com/github/super-linter>.