### PR TITLE
Adding config.yml

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,13 @@
+# © Muiris Woulfe
+# Licensed under the MIT License
+
+---
+
+blank_issues_enabled: false
+
+contact_links:
+  - name: Support
+    url: https://github.com/muiriswoulfe/NuGet-Transitive-Dependency-Finder/discussions/new?category=q-a
+    about: Request support for the project
+
+...

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -7,7 +7,7 @@ blank_issues_enabled: false
 
 contact_links:
   - name: Support
-    url: https://github.com/muiriswoulfe/NuGet-Transitive-Dependency-Finder/discussions/new?category=q-a
+    url: https://github.com/muiriswoulfe/NuGet-Transitive-Dependency-Finder/discussions
     about: Request support for the project
 
 ...

--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -33,7 +33,7 @@ You should also consider:
 <!-- References -->
 
 [discussion]:
-  https://github.com/muiriswoulfe/NuGet-Transitive-Dependency-Finder/discussions/new?category=q-a
+  https://github.com/muiriswoulfe/NuGet-Transitive-Dependency-Finder/discussions
 [rubberduckdebugging]:
   https://wikipedia.org/wiki/Rubber_duck_debugging
 [xyproblem]:

--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -33,7 +33,7 @@ You should also consider:
 <!-- References -->
 
 [discussion]:
-  https://github.com/muiriswoulfe/NuGet-Transitive-Dependency-Finder/discussions
+  https://github.com/muiriswoulfe/NuGet-Transitive-Dependency-Finder/discussions/new?category=q-a
 [rubberduckdebugging]:
   https://wikipedia.org/wiki/Rubber_duck_debugging
 [xyproblem]:


### PR DESCRIPTION
# Pull Request

## Summary

Adding a `config.yml` file as documented at <https://docs.github.com/en/github/building-a-strong-community/configuring-issue-templates-for-your-repository#configuring-the-template-chooser>. This file acts as an Issue template chooser within GitHub.

## Behavior

### Previous

No `config.yml` file was present. The default GitHub template choosing logic applied.

### New

The template choosing logic from `config.yml` now applies. This adds a link to the support discussions page and removes the option of creating a blank issue.

## Breaking Changes

None, as this has no impact on the project code.

## Testing Undertaken

The template chooser was tested using a private repo.