### PR TITLE
Reducing duplication within "Build" GitHub Action

### DIFF
--- a/.github/linters/.jscpd.json
+++ b/.github/linters/.jscpd.json
@@ -1,0 +1,6 @@
+{
+  "ignore": [
+    ".github/workflows/build.yml",
+    ".github/workflows/release.yml"
+  ]
+}

--- a/.github/linters/.jscpd.json
+++ b/.github/linters/.jscpd.json
@@ -1,3 +1,0 @@
-{
-  "ignore": ["**/workflows/*.yml"]
-}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,24 +30,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: INITIALIZATION – Get Tag
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        id: tag
-        uses: jossef/action-latest-release-info@master
-
-      - name: INITIALIZATION – Version Extract
-        id: version
-        run: |-
-          $Version = '${{ steps.tag.outputs.tag_name }}'.Substring(1)
-          Write-Output -InputObject "::set-output name=version::$Version"
-
-      - name: INITIALIZATION – Version Replace
-        run: |-
-          $FileContent = Get-Content -Path 'src/Shared/Properties/AssemblyAttributes.cs' -Raw
-          $FileContent = $FileContent -replace '0.0.0', '${{ steps.version.outputs.version }}'
-          Set-Content -NoNewline -Path 'src/Shared/Properties/AssemblyAttributes.cs' -Value $FileContent
-
       - name: INITIALIZATION – .NET Install
         uses: actions/setup-dotnet@main
 
@@ -340,24 +322,6 @@ jobs:
       - name: INITIALIZATION – Checkout
         uses: actions/checkout@main
 
-      - name: INITIALIZATION – Get Tag
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        id: tag
-        uses: jossef/action-latest-release-info@master
-
-      - name: INITIALIZATION – Version Extract
-        id: version
-        run: |-
-          $Version = '${{ steps.tag.outputs.tag_name }}'.Substring(1)
-          Write-Output -InputObject "::set-output name=version::$Version"
-
-      - name: INITIALIZATION – Version Replace
-        run: |-
-          $FileContent = Get-Content -Path 'src/Shared/Properties/AssemblyAttributes.cs' -Raw
-          $FileContent = $FileContent -replace '0.0.0', '${{ steps.version.outputs.version }}'
-          Set-Content -NoNewline -Path 'src/Shared/Properties/AssemblyAttributes.cs' -Value $FileContent
-
       # Markdown Validation
       - name: MARKDOWN VALIDATION – Validate Links
         uses: gaurav-nelson/github-action-markdown-link-check@master
@@ -412,24 +376,6 @@ jobs:
       - name: INITIALIZATION – Checkout
         uses: actions/checkout@main
 
-      - name: INITIALIZATION – Get Tag
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        id: tag
-        uses: jossef/action-latest-release-info@master
-
-      - name: INITIALIZATION – Version Extract
-        id: version
-        run: |-
-          $Version = '${{ steps.tag.outputs.tag_name }}'.Substring(1)
-          Write-Output -InputObject "::set-output name=version::$Version"
-
-      - name: INITIALIZATION – Version Replace
-        run: |-
-          $FileContent = Get-Content -Path 'src/Shared/Properties/AssemblyAttributes.cs' -Raw
-          $FileContent = $FileContent -replace '0.0.0', '${{ steps.version.outputs.version }}'
-          Set-Content -NoNewline -Path 'src/Shared/Properties/AssemblyAttributes.cs' -Value $FileContent
-
       # Validation
       - name: VALIDATION – Super Linter
         uses: github/super-linter@master
@@ -446,24 +392,6 @@ jobs:
       # Initialization
       - name: INITIALIZATION – Checkout
         uses: actions/checkout@main
-
-      - name: INITIALIZATION – Get Tag
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        id: tag
-        uses: jossef/action-latest-release-info@master
-
-      - name: INITIALIZATION – Version Extract
-        id: version
-        run: |-
-          $Version = '${{ steps.tag.outputs.tag_name }}'.Substring(1)
-          Write-Output -InputObject "::set-output name=version::$Version"
-
-      - name: INITIALIZATION – Version Replace
-        run: |-
-          $FileContent = Get-Content -Path 'src/Shared/Properties/AssemblyAttributes.cs' -Raw
-          $FileContent = $FileContent -replace '0.0.0', '${{ steps.version.outputs.version }}'
-          Set-Content -NoNewline -Path 'src/Shared/Properties/AssemblyAttributes.cs' -Value $FileContent
 
       # Validation
       - name: VALIDATION – CodeQL Initialize

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ defaults:
     shell: pwsh
 
 jobs:
-  build-debug:
+  build:
     name: Build
     runs-on: ubuntu-latest
     strategy:
@@ -76,8 +76,43 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: .sonarcloud/dotnet-sonarscanner end /d:sonar.login="${{ secrets.SONAR_TOKEN }}"
 
+  replace-version:
+    name: Replace Version
+    runs-on: ubuntu-latest
+    steps:
+      # Initialization
+      - name: INITIALIZATION – Checkout
+        uses: actions/checkout@main
+
+      - name: INITIALIZATION – Get Tag
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        id: tag
+        uses: jossef/action-latest-release-info@master
+
+      - name: INITIALIZATION – Version Extract
+        id: version
+        run: |-
+          $Version = '${{ steps.tag.outputs.tag_name }}'.Substring(1)
+          Write-Output -InputObject "::set-output name=version::$Version"
+
+      - name: INITIALIZATION – Version Replace
+        run: |-
+          $FileContent = Get-Content -Path 'src/Shared/Properties/AssemblyAttributes.cs' -Raw
+          $FileContent = $FileContent -replace '0.0.0', '${{ steps.version.outputs.version }}'
+          Set-Content -NoNewline -Path 'src/Shared/Properties/AssemblyAttributes.cs' -Value $FileContent
+
+      # Store
+      - name: STORE – Upload AssemblyAttributes.cs
+        uses: actions/upload-artifact@main
+        with:
+          name: AssemblyAttributes.cs
+          path: src/Shared/Properties/AssemblyAttributes.cs
+          retention-days: 1
+
   create-asset:
     name: Create Asset
+    needs: replace-version
     runs-on: ubuntu-latest
     env:
       project: NuGetTransitiveDependencyFinder.ConsoleApp
@@ -101,23 +136,11 @@ jobs:
       - name: INITIALIZATION – Checkout
         uses: actions/checkout@main
 
-      - name: INITIALIZATION – Get Tag
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        id: tag
-        uses: jossef/action-latest-release-info@master
-
-      - name: INITIALIZATION – Version Extract
-        id: version
-        run: |-
-          $Version = '${{ steps.tag.outputs.tag_name }}'.Substring(1)
-          Write-Output -InputObject "::set-output name=version::$Version"
-
-      - name: INITIALIZATION – Version Replace
-        run: |-
-          $FileContent = Get-Content -Path 'src/Shared/Properties/AssemblyAttributes.cs' -Raw
-          $FileContent = $FileContent -replace '0.0.0', '${{ steps.version.outputs.version }}'
-          Set-Content -NoNewline -Path 'src/Shared/Properties/AssemblyAttributes.cs' -Value $FileContent
+      - name: INITIALIZATION – Download AssemblyAttributes.cs
+        uses: actions/download-artifact@main
+        with:
+          name: AssemblyAttributes.cs
+          path: src/Shared/Properties/AssemblyAttributes.cs
 
       - name: INITIALIZATION – .NET Install
         uses: actions/setup-dotnet@main
@@ -179,6 +202,7 @@ jobs:
 
   create-nuget:
     name: Create NuGet Package
+    needs: replace-version
     runs-on: ubuntu-latest
     env:
       nuget-package-prefix: src/NuGetTransitiveDependencyFinder/bin/Release/NuGetTransitiveDependencyFinder
@@ -187,23 +211,11 @@ jobs:
       - name: INITIALIZATION – Checkout
         uses: actions/checkout@main
 
-      - name: INITIALIZATION – Get Tag
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        id: tag
-        uses: jossef/action-latest-release-info@master
-
-      - name: INITIALIZATION – Version Extract
-        id: version
-        run: |-
-          $Version = '${{ steps.tag.outputs.tag_name }}'.Substring(1)
-          Write-Output -InputObject "::set-output name=version::$Version"
-
-      - name: INITIALIZATION – Version Replace
-        run: |-
-          $FileContent = Get-Content -Path 'src/Shared/Properties/AssemblyAttributes.cs' -Raw
-          $FileContent = $FileContent -replace '0.0.0', '${{ steps.version.outputs.version }}'
-          Set-Content -NoNewline -Path 'src/Shared/Properties/AssemblyAttributes.cs' -Value $FileContent
+      - name: INITIALIZATION – Download AssemblyAttributes.cs
+        uses: actions/download-artifact@main
+        with:
+          name: AssemblyAttributes.cs
+          path: src/Shared/Properties/AssemblyAttributes.cs
 
       - name: INITIALIZATION – .NET Install
         uses: actions/setup-dotnet@main

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -136,6 +136,9 @@ jobs:
       - name: INITIALIZATION – Checkout
         uses: actions/checkout@main
 
+      - name: INITIALIZATION – Delete AssemblyAttributes.cs
+        run: Remove-Item -Path 'src/Shared/Properties/AssemblyAttributes.cs'
+
       - name: INITIALIZATION – Download AssemblyAttributes.cs
         uses: actions/download-artifact@main
         with:
@@ -210,6 +213,9 @@ jobs:
       # Initialization
       - name: INITIALIZATION – Checkout
         uses: actions/checkout@main
+
+      - name: INITIALIZATION – Delete AssemblyAttributes.cs
+        run: Remove-Item -Path 'src/Shared/Properties/AssemblyAttributes.cs'
 
       - name: INITIALIZATION – Download AssemblyAttributes.cs
         uses: actions/download-artifact@main

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,43 +76,8 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: .sonarcloud/dotnet-sonarscanner end /d:sonar.login="${{ secrets.SONAR_TOKEN }}"
 
-  replace-version:
-    name: Replace Version
-    runs-on: ubuntu-latest
-    steps:
-      # Initialization
-      - name: INITIALIZATION – Checkout
-        uses: actions/checkout@main
-
-      - name: INITIALIZATION – Get Tag
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        id: tag
-        uses: jossef/action-latest-release-info@master
-
-      - name: INITIALIZATION – Version Extract
-        id: version
-        run: |-
-          $Version = '${{ steps.tag.outputs.tag_name }}'.Substring(1)
-          Write-Output -InputObject "::set-output name=version::$Version"
-
-      - name: INITIALIZATION – Version Replace
-        run: |-
-          $FileContent = Get-Content -Path 'src/Shared/Properties/AssemblyAttributes.cs' -Raw
-          $FileContent = $FileContent -replace '0.0.0', '${{ steps.version.outputs.version }}'
-          Set-Content -NoNewline -Path 'src/Shared/Properties/AssemblyAttributes.cs' -Value $FileContent
-
-      # Store
-      - name: STORE – Upload AssemblyAttributes.cs
-        uses: actions/upload-artifact@main
-        with:
-          name: AssemblyAttributes.cs
-          path: src/Shared/Properties/AssemblyAttributes.cs
-          retention-days: 1
-
   create-asset:
     name: Create Asset
-    needs: replace-version
     runs-on: ubuntu-latest
     env:
       project: NuGetTransitiveDependencyFinder.ConsoleApp
@@ -136,14 +101,23 @@ jobs:
       - name: INITIALIZATION – Checkout
         uses: actions/checkout@main
 
-      - name: INITIALIZATION – Delete AssemblyAttributes.cs
-        run: Remove-Item -Path 'src/Shared/Properties/AssemblyAttributes.cs'
+      - name: INITIALIZATION – Get Tag
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        id: tag
+        uses: jossef/action-latest-release-info@master
 
-      - name: INITIALIZATION – Download AssemblyAttributes.cs
-        uses: actions/download-artifact@main
-        with:
-          name: AssemblyAttributes.cs
-          path: src/Shared/Properties/AssemblyAttributes.cs
+      - name: INITIALIZATION – Version Extract
+        id: version
+        run: |-
+          $Version = '${{ steps.tag.outputs.tag_name }}'.Substring(1)
+          Write-Output -InputObject "::set-output name=version::$Version"
+
+      - name: INITIALIZATION – Version Replace
+        run: |-
+          $FileContent = Get-Content -Path 'src/Shared/Properties/AssemblyAttributes.cs' -Raw
+          $FileContent = $FileContent -replace '0.0.0', '${{ steps.version.outputs.version }}'
+          Set-Content -NoNewline -Path 'src/Shared/Properties/AssemblyAttributes.cs' -Value $FileContent
 
       - name: INITIALIZATION – .NET Install
         uses: actions/setup-dotnet@main
@@ -205,7 +179,6 @@ jobs:
 
   create-nuget:
     name: Create NuGet Package
-    needs: replace-version
     runs-on: ubuntu-latest
     env:
       nuget-package-prefix: src/NuGetTransitiveDependencyFinder/bin/Release/NuGetTransitiveDependencyFinder
@@ -214,14 +187,23 @@ jobs:
       - name: INITIALIZATION – Checkout
         uses: actions/checkout@main
 
-      - name: INITIALIZATION – Delete AssemblyAttributes.cs
-        run: Remove-Item -Path 'src/Shared/Properties/AssemblyAttributes.cs'
+      - name: INITIALIZATION – Get Tag
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        id: tag
+        uses: jossef/action-latest-release-info@master
 
-      - name: INITIALIZATION – Download AssemblyAttributes.cs
-        uses: actions/download-artifact@main
-        with:
-          name: AssemblyAttributes.cs
-          path: src/Shared/Properties/AssemblyAttributes.cs
+      - name: INITIALIZATION – Version Extract
+        id: version
+        run: |-
+          $Version = '${{ steps.tag.outputs.tag_name }}'.Substring(1)
+          Write-Output -InputObject "::set-output name=version::$Version"
+
+      - name: INITIALIZATION – Version Replace
+        run: |-
+          $FileContent = Get-Content -Path 'src/Shared/Properties/AssemblyAttributes.cs' -Raw
+          $FileContent = $FileContent -replace '0.0.0', '${{ steps.version.outputs.version }}'
+          Set-Content -NoNewline -Path 'src/Shared/Properties/AssemblyAttributes.cs' -Value $FileContent
 
       - name: INITIALIZATION – .NET Install
         uses: actions/setup-dotnet@main


### PR DESCRIPTION
# Pull Request

## Summary

Reducing duplication within the "Build" GitHub Action, by avoiding repeatedly replacing the placeholder version with the latest tag. This serves to enhance maintainability and improve build performance.

The suppression for the JSCPD logic within the Super-Linter has also been updated.

## Behavior

### Previous

Each stage within the "Build" GitHub Action replaced the placeholder version with the latest tag, even when this update was not directly used within that build step.

### New

The superfluous replacement of the version numbers has been removed.

## Breaking Changes

The build pipeline has been modified, but in a way that should be transparent to consumers.

## Testing Undertaken

The build pipeline was validated to run successfully and generate the expected outputs with these changes in place.