### PR TITLE
Adding Application Inspector to Build Action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -393,16 +393,6 @@ jobs:
           json-file: src/stylecop.json
           json-schema: stylecop.schema.json
 
-      # Application Inspector
-      - name: APPLICATION INSPECTOR – Validate
-        uses: microsoft/ApplicationInspector-Action@main
-
-      - name: APPLICATION INSPECTOR – Upload Results
-        uses: actions/upload-artifact@main
-        with:
-          name: Application Inspector Results
-          path: AppInspectorResults.json
-
       # Security Scan
       - name: SECURITY SCAN – Validate
         uses: ShiftLeftSecurity/scan-action@master
@@ -413,6 +403,16 @@ jobs:
         uses: github/codeql-action/upload-sarif@main
         with:
           sarif_file: reports
+
+      # Application Inspector
+      - name: APPLICATION INSPECTOR – Run
+        uses: microsoft/ApplicationInspector-Action@main
+
+      - name: APPLICATION INSPECTOR – Upload Results
+        uses: actions/upload-artifact@main
+        with:
+          name: Application Inspector Results
+          path: AppInspectorResults.json
 
   validate-lint:
     name: Validate – Lint

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -393,6 +393,16 @@ jobs:
           json-file: src/stylecop.json
           json-schema: stylecop.schema.json
 
+      # Application Inspector
+      - name: APPLICATION INSPECTOR – Validate
+        uses: microsoft/ApplicationInspector-Action@main
+
+      - name: APPLICATION INSPECTOR – Upload Results
+        uses: actions/upload-artifact@main
+        with:
+          name: Application Inspector Results
+          path: AppInspectorResults.json
+
       # Security Scan
       - name: SECURITY SCAN – Validate
         uses: ShiftLeftSecurity/scan-action@master


### PR DESCRIPTION
# Pull Request

## Summary

Adding the [Application Inspector GitHub Action](https://github.com/microsoft/ApplicationInspector-Action/) to the build action, to gain greater insight into the APIs and features of the project as it progresses.

## Behavior

### Previous

The Application Inspector was not present in the build action.

### New

The Application Inspector is now present in the build action.

## Breaking Changes

None, as this only impacts validation performed as part of the build action. It has no impact on the project or its build process.

## Testing Undertaken

The build action was run successfully.