### PR TITLE
Enabling SonarCloud test coverage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,8 +52,7 @@ jobs:
           /o:"${{ github.repository_owner }}"
           /d:sonar.login="${{ secrets.SONAR_TOKEN }}"
           /d:sonar.host.url="https://sonarcloud.io"
-          /d:sonar.cs.opencover.reportsPaths="**/TestResults/**/coverage.opencover.xml"
-          /d:sonar.cs.vstest.reportsPaths="**/TestResults/*.trx"
+          /d:sonar.cs.opencover.reportsPaths="src/**/coverage.opencover.xml"
 
       # Build & Test
       - name: BUILD & TEST – Project Restore
@@ -67,7 +66,6 @@ jobs:
           dotnet test
           --configuration ${{ matrix.configuration }}
           --no-build
-          --logger trx
           /property:CollectCoverage=true
           /property:CoverletOutputFormat=opencover
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,6 +52,8 @@ jobs:
           /o:"${{ github.repository_owner }}"
           /d:sonar.login="${{ secrets.SONAR_TOKEN }}"
           /d:sonar.host.url="https://sonarcloud.io"
+          /d:sonar.cs.opencover.reportsPaths="**/TestResults/**/coverage.opencover.xml"
+          /d:sonar.cs.vstest.reportsPaths="**/TestResults/*.trx"
 
       # Build & Test
       - name: BUILD & TEST – Project Restore
@@ -65,6 +67,7 @@ jobs:
           dotnet test
           --configuration ${{ matrix.configuration }}
           --no-build
+          --logger trx
           /property:CollectCoverage=true
           /property:CoverletOutputFormat=opencover
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -323,48 +323,13 @@ jobs:
           Write-Output -InputObject "NuGet Package: $NuGetPackageSize"
           Write-Output -InputObject "NuGet Symbols Package: $NuGetSymbolsPackageSize"
 
-  validate:
-    name: Validate
+  validate-security:
+    name: Validate – Security
     runs-on: ubuntu-latest
     steps:
       # Initialization
       - name: INITIALIZATION – Checkout
         uses: actions/checkout@main
-
-      # Markdown Validation
-      - name: MARKDOWN VALIDATION – Validate Links
-        uses: gaurav-nelson/github-action-markdown-link-check@master
-        with:
-          config-file: .github/linters/markdown-link-check.json
-
-      # JSON Validation
-      - name: JSON VALIDATION – Validate .markdownlint.json
-        uses: Zingabopp/JsonValidate-Action@master
-        with:
-          json-file: .markdownlint.json
-          json-schema: >-
-            https://raw.githubusercontent.com/DavidAnson/markdownlint/main/schema/markdownlint-config-schema.json
-          use-draft: draft-07
-
-      - name: JSON VALIDATION – Validate src/stylecop.json – Download stylecop.schema.json
-        env:
-          project_url: https://raw.githubusercontent.com/DotNetAnalyzers/StyleCopAnalyzers/master
-        run: >-
-          Invoke-WebRequest
-          -Uri '${{ env.project_url }}/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json'
-          -OutFile 'stylecop.schema.json'
-
-      - name: JSON VALIDATION – Validate src/stylecop.json – Update stylecop.schema.json
-        run: |-
-          $FileContent = Get-Content -Path 'stylecop.schema.json' -Raw
-          $FileContent = $FileContent -replace 'draft-04/schema#', 'draft-07/schema'
-          Set-Content -NoNewline -Path 'stylecop.schema.json' -Value $FileContent
-
-      - name: JSON VALIDATION – Validate src/stylecop.json
-        uses: Zingabopp/JsonValidate-Action@master
-        with:
-          json-file: src/stylecop.json
-          json-schema: stylecop.schema.json
 
       # INFER#
       - name: INFER# – Validation
@@ -405,14 +370,49 @@ jobs:
       - name: INITIALIZATION – Checkout
         uses: actions/checkout@main
 
-      # Validation
-      - name: VALIDATION – Super Linter
+      # Linter Validation
+      - name: LINTER VALIDATION – Super Linter
         uses: github/super-linter@master
         env:
           EDITORCONFIG_FILE_NAME: ../../.editorconfig
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MARKDOWN_CONFIG_FILE: ../../.markdownlint.json
           VALIDATE_CSHARP: false
+
+      # Markdown Validation
+      - name: MARKDOWN VALIDATION – Validate Links
+        uses: gaurav-nelson/github-action-markdown-link-check@master
+        with:
+          config-file: .github/linters/markdown-link-check.json
+
+      # JSON Validation
+      - name: JSON VALIDATION – Validate .markdownlint.json
+        uses: Zingabopp/JsonValidate-Action@master
+        with:
+          json-file: .markdownlint.json
+          json-schema: >-
+            https://raw.githubusercontent.com/DavidAnson/markdownlint/main/schema/markdownlint-config-schema.json
+          use-draft: draft-07
+
+      - name: JSON VALIDATION – Validate src/stylecop.json – Download stylecop.schema.json
+        env:
+          project_url: https://raw.githubusercontent.com/DotNetAnalyzers/StyleCopAnalyzers/master
+        run: >-
+          Invoke-WebRequest
+          -Uri '${{ env.project_url }}/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json'
+          -OutFile 'stylecop.schema.json'
+
+      - name: JSON VALIDATION – Validate src/stylecop.json – Update stylecop.schema.json
+        run: |-
+          $FileContent = Get-Content -Path 'stylecop.schema.json' -Raw
+          $FileContent = $FileContent -replace 'draft-04/schema#', 'draft-07/schema'
+          Set-Content -NoNewline -Path 'stylecop.schema.json' -Value $FileContent
+
+      - name: JSON VALIDATION – Validate src/stylecop.json
+        uses: Zingabopp/JsonValidate-Action@master
+        with:
+          json-file: src/stylecop.json
+          json-schema: stylecop.schema.json
 
   validate-codeql:
     name: Validate – CodeQL

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -323,45 +323,6 @@ jobs:
           Write-Output -InputObject "NuGet Package: $NuGetPackageSize"
           Write-Output -InputObject "NuGet Symbols Package: $NuGetSymbolsPackageSize"
 
-  validate-security:
-    name: Validate – Security
-    runs-on: ubuntu-latest
-    steps:
-      # Initialization
-      - name: INITIALIZATION – Checkout
-        uses: actions/checkout@main
-
-      # INFER#
-      - name: INFER# – Validation
-        id: infersharp
-        uses: microsoft/infersharpaction@main
-        with:
-          binary-path: src
-
-      - name: INFER# – Print Results
-        run: Write-Output -InputObject '${{ steps.infersharp.outputs.results }}'
-
-      # Security Scan
-      - name: SECURITY SCAN – Validate
-        uses: ShiftLeftSecurity/scan-action@master
-        with:
-          type: credscan,depscan
-
-      - name: SECURITY SCAN – Upload Report
-        uses: github/codeql-action/upload-sarif@main
-        with:
-          sarif_file: reports
-
-      # Application Inspector
-      - name: APPLICATION INSPECTOR – Run
-        uses: microsoft/ApplicationInspector-Action@main
-
-      - name: APPLICATION INSPECTOR – Upload Results
-        uses: actions/upload-artifact@main
-        with:
-          name: Application Inspector Results
-          path: AppInspectorResults.json
-
   validate-lint:
     name: Validate – Lint
     runs-on: ubuntu-latest
@@ -413,6 +374,45 @@ jobs:
         with:
           json-file: src/stylecop.json
           json-schema: stylecop.schema.json
+
+  validate-security:
+    name: Validate – Security
+    runs-on: ubuntu-latest
+    steps:
+      # Initialization
+      - name: INITIALIZATION – Checkout
+        uses: actions/checkout@main
+
+      # INFER#
+      - name: INFER# – Validation
+        id: infersharp
+        uses: microsoft/infersharpaction@main
+        with:
+          binary-path: src
+
+      - name: INFER# – Print Results
+        run: Write-Output -InputObject '${{ steps.infersharp.outputs.results }}'
+
+      # Security Scan
+      - name: SECURITY SCAN – Validate
+        uses: ShiftLeftSecurity/scan-action@master
+        with:
+          type: credscan,depscan
+
+      - name: SECURITY SCAN – Upload Report
+        uses: github/codeql-action/upload-sarif@main
+        with:
+          sarif_file: reports
+
+      # Application Inspector
+      - name: APPLICATION INSPECTOR – Run
+        uses: microsoft/ApplicationInspector-Action@main
+
+      - name: APPLICATION INSPECTOR – Upload Results
+        uses: actions/upload-artifact@main
+        with:
+          name: Application Inspector Results
+          path: AppInspectorResults.json
 
   validate-codeql:
     name: Validate – CodeQL


### PR DESCRIPTION
# Pull Request

## Summary

Enabling SonarCloud test coverage by modifying parameters passed via SonarQube invocation.

This change also includes small modifications to the ordering of the build operations in order to minimize overall running times.

## Behavior

### Previous

SonarCloud test coverage was previously at zero and failed to reflect the recent addition of unit tests.

### New

SonarCloud test coverage now correctly reflects the actual project test coverage.

## Breaking Changes

None, as this only modifies the build parameters invoking SonarCloud.

## Testing Undertaken

The build action was successfully ran.