### PR TITLE
Adding CodeQL suppressions

### DIFF
--- a/src/Tests/NuGetTransitiveDependencyFinder.UnitTests/Output/DependencyUnitTests.cs
+++ b/src/Tests/NuGetTransitiveDependencyFinder.UnitTests/Output/DependencyUnitTests.cs
@@ -409,7 +409,7 @@ namespace NuGetTransitiveDependencyFinder.UnitTests.Output
         public void EqualsObject_WithDifferentObjectTypes_ReturnsFalse()
         {
             // Act
-            var result = DefaultValue.Equals("value");
+            var result = DefaultValue.Equals("value"); // lgtm[cs/equals-on-unrelated-types]
 
             // Assert
             _ = result.Should().Be(false);

--- a/src/Tests/NuGetTransitiveDependencyFinder.UnitTests/Output/FrameworkUnitTests.cs
+++ b/src/Tests/NuGetTransitiveDependencyFinder.UnitTests/Output/FrameworkUnitTests.cs
@@ -423,7 +423,7 @@ namespace NuGetTransitiveDependencyFinder.UnitTests.Output
         public void EqualsObject_WithDifferentObjectTypes_ReturnsFalse()
         {
             // Act
-            var result = DefaultValue.Equals("value");
+            var result = DefaultValue.Equals("value"); // lgtm[cs/equals-on-unrelated-types]
 
             // Assert
             _ = result.Should().Be(false);

--- a/src/Tests/NuGetTransitiveDependencyFinder.UnitTests/Output/ProjectUnitTests.cs
+++ b/src/Tests/NuGetTransitiveDependencyFinder.UnitTests/Output/ProjectUnitTests.cs
@@ -374,7 +374,7 @@ namespace NuGetTransitiveDependencyFinder.UnitTests.Output
         public void EqualsObject_WithDifferentObjectTypes_ReturnsFalse()
         {
             // Act
-            var result = DefaultValue.Equals("value");
+            var result = DefaultValue.Equals("value"); // lgtm[cs/equals-on-unrelated-types]
 
             // Assert
             _ = result.Should().Be(false);

--- a/src/Tests/NuGetTransitiveDependencyFinder.UnitTests/Output/VersionUnitTests.cs
+++ b/src/Tests/NuGetTransitiveDependencyFinder.UnitTests/Output/VersionUnitTests.cs
@@ -309,7 +309,7 @@ namespace NuGetTransitiveDependencyFinder.UnitTests.Output
         public void EqualsObject_WithDifferentObjectTypes_ReturnsFalse()
         {
             // Act
-            var result = DefaultValue.Equals("value");
+            var result = DefaultValue.Equals("value"); // lgtm[cs/equals-on-unrelated-types]
 
             // Assert
             _ = result.Should().Be(false);


### PR DESCRIPTION
# Pull Request

## Summary

Suppressing known issues detected by CodeQL within the unit tests. These issues are deliberately present to test the behavior of otherwise invalid code paths.

## Behavior

### Previous

The suppressions were not present, and the issues (related to mismatched types passed to the `Equals` method) were detected by CodeQL.

### New

The suppressions, in the form of comments, have now been added.

## Breaking Changes

None, as the only code changes are the addition of suppression comments.

## Testing Undertaken

CodeQL was validated to no longer flag the issues for remediation.