### PR TITLE
Changing NuGet packages location

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -2,7 +2,7 @@
 <configuration>
   <config>
     <add key="dependencyVersion" value="Highest"/>
-    <add key="globalPackagesFolder" value="..\packages"/>
+    <add key="globalPackagesFolder" value="..\packages\NuGetTransitiveDependencyFinder"/>
     <add key="signatureValidationMode" value="require"/>
   </config>
 

--- a/NuGet.config
+++ b/NuGet.config
@@ -2,7 +2,7 @@
 <configuration>
   <config>
     <add key="dependencyVersion" value="Highest"/>
-    <add key="globalPackagesFolder" value="packages"/>
+    <add key="globalPackagesFolder" value="..\packages"/>
     <add key="signatureValidationMode" value="require"/>
   </config>
 


### PR DESCRIPTION
# Pull Request

## Summary

Changing the NuGet packages location to avoid flagging of CodeQL issues within dependencies.

## Behavior

### Previous

The NuGet packages were placed within the "packages" folder inside the solution folder.

### New

The NuGet packages are now placed within the "..\packages\NuGetTransitiveDependencyFinder" folder inside the solution folder (i.e. from one level below the solution folder).

## Breaking Changes

None, from the perspective of external callers as these changes merely impact the build process.

## Testing Undertaken

These changes were validated to run locally as well as through the GitHub Actions.