### PR TITLE
Disabling codecov for dependabot PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,7 +78,10 @@ jobs:
       - name: BUILD & TEST – Project Test
         run: dotnet test --configuration ${{ matrix.configuration }} --no-build --collect:"XPlat Code Coverage"
 
-      - if: matrix.configuration == 'Release' && matrix.os == 'ubuntu-latest'
+      - if: >-
+          matrix.configuration == 'Release' &&
+          matrix.os == 'ubuntu-latest' &&
+          !startsWith(github.head_ref, 'dependabot/')
         name: BUILD & TEST – Upload to Codecov
         uses: codecov/codecov-action@v1
         with:


### PR DESCRIPTION
# Pull Request

## Summary

Disabling CodeCov within the **Build** GitHub Action for PRs created by Dependabot. This change is being made to stop unnecessary runs of CodeCov, which fail to correct detect code coverage for these PRs.

## Behavior

### Previous

CodeCov would run for Dependabot builds but always detect 0% code coverage.

### New

CodeCov will not run for Dependabot builds.

## Breaking Changes

No breaking changes, as no code changes have been made.

## Testing Undertaken

The **Build** GitHub Action has been verified to continue to run correctly for normal PR builds. It will be verified that the changes made result in the correct behavior for Dependabot PRs when the next Dependabot PR is created.
