### PR TITLE
Updating Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,7 @@ version: 2
 updates:
   - package-ecosystem: github-actions
     directory: /
+    open-pull-requests-limit: 0
     schedule:
       interval: daily
     labels:
@@ -19,6 +20,7 @@ updates:
 
   - package-ecosystem: nuget
     directory: /
+    open-pull-requests-limit: 0
     schedule:
       interval: daily
     labels:


### PR DESCRIPTION
# Pull Request

## Summary

Updating the Dependabot configuration to remove the restriction on the number of PRs that can be opened.