### PR TITLE
Updating .NET Core to SDK v5.0.302

### DIFF
--- a/global.json
+++ b/global.json
@@ -2,6 +2,6 @@
   "sdk": {
     "allowPrerelease": false,
     "rollForward": "latestMajor",
-    "version": "5.0.301"
+    "version": "5.0.302"
   }
 }


### PR DESCRIPTION
# Pull Request

## Summary

Updating .NET Core to SDK v5.0.302, aka [v5.0.8](https://github.com/dotnet/core/releases/tag/v5.0.8), which was released today.