### PR TITLE
Updating .NET to v5.0.400

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           distribution: zulu
-          java-version: 16.0.1
+          java-version: 16.0.2
 
       - if: >-
           ${{ matrix.configuration == 'Release'

--- a/global.json
+++ b/global.json
@@ -2,6 +2,6 @@
   "sdk": {
     "allowPrerelease": false,
     "rollForward": "latestMajor",
-    "version": "5.0.302"
+    "version": "5.0.400"
   }
 }


### PR DESCRIPTION
# Pull Request

Updating .NET from v5.0.302 to v5.0.400 (aka v5.0.9), following its release.

Release details can be located at <https://github.com/dotnet/core/releases/tag/v5.0.9>.

This change also updates the Java SDK dependency, used by SonarCloud within the Build GitHub Action, from v16.0.1 to v16.0.2.