### PR TITLE
Updating .NET Core to v5.0.401

### DIFF
--- a/global.json
+++ b/global.json
@@ -2,6 +2,6 @@
   "sdk": {
     "allowPrerelease": false,
     "rollForward": "latestMajor",
-    "version": "5.0.400"
+    "version": "5.0.401"
   }
 }


### PR DESCRIPTION
# Pull Request

Updating .NET Core to v5.0.401 (v5.0.10) following its release. Release notes can be found at <https://github.com/dotnet/core/releases/tag/v5.0.10>.