### PR TITLE
Updating .NET to v5.0.402

### DIFF
--- a/global.json
+++ b/global.json
@@ -2,6 +2,6 @@
   "sdk": {
     "allowPrerelease": false,
     "rollForward": "latestMajor",
-    "version": "5.0.401"
+    "version": "5.0.402"
   }
 }


### PR DESCRIPTION
# Pull Request

Updating .NET to v5.0.402 (v5.0.11) following its release. Release notes can be found at <https://github.com/dotnet/core/releases/tag/v5.0.11>.