### PR TITLE
Use dependencies from assets file

### DIFF
--- a/src/Product/NuGetTransitiveDependencyFinder/ProjectAnalysis/DependencyFinder.cs
+++ b/src/Product/NuGetTransitiveDependencyFinder/ProjectAnalysis/DependencyFinder.cs
@@ -57,8 +57,8 @@ namespace NuGetTransitiveDependencyFinder.ProjectAnalysis
             var result = new Projects(projects.Count);
             foreach (var project in projects)
             {
-                var assetsFiles = this.CreateAssetsFiles(project);
-                if (assetsFiles is null)
+                var assetsFile = this.CreateAssetsFile(project);
+                if (assetsFile is null)
                 {
                     continue;
                 }
@@ -67,12 +67,34 @@ namespace NuGetTransitiveDependencyFinder.ProjectAnalysis
                 foreach (var framework in project.TargetFrameworks)
                 {
                     this.dependencies.Clear();
-                    var libraries = assetsFiles
+
+                    var libraries = assetsFile
+                        .Targets
                         .First(target => target.TargetFramework == framework.FrameworkName)
                         .Libraries
                         .ToImmutableDictionary(library => library.Name, StringComparer.OrdinalIgnoreCase);
-                    this.PopulateDependencies(framework, libraries);
-                    var resultFramework = this.FindTransitiveDependencies(framework, collateAllDependencies, filter);
+
+                    var projectDependencyGroup = assetsFile
+                        .ProjectFileDependencyGroups
+                        .FirstOrDefault(target =>
+                            target.FrameworkName == framework.TargetAlias ||
+                            target.FrameworkName == framework.FrameworkName.DotNetFrameworkName);
+
+                    if (projectDependencyGroup is null)
+                    {
+                        continue;
+                    }
+
+                    var projectDependencies = projectDependencyGroup
+                        .Dependencies
+                        .Select(dependency =>
+                            libraries.TryGetValue(dependency.Split(" ")[0], out var library) ? library : null)
+                        .Where(library => library is not null);
+
+                    this.PopulateDependencies(libraries);
+
+                    var resultFramework = this.FindTransitiveDependencies(
+                        framework, projectDependencies!, collateAllDependencies, filter);
 
                     resultProject.Add(resultFramework);
                 }
@@ -106,32 +128,22 @@ namespace NuGetTransitiveDependencyFinder.ProjectAnalysis
             this.dependencyGraph.Create(projectOrSolutionPath);
 
         /// <summary>
-        /// Creates the collection of assets files to be analyzed.
+        /// Creates the assets file to be analyzed.
         /// </summary>
         /// <param name="project">The .NET project to analyze.</param>
-        /// <returns>The collection of assets files.</returns>
-        private IReadOnlyCollection<LockFileTarget>? CreateAssetsFiles(PackageSpec project)
-        {
-            var createdAssets = this.assets
-                .Create(project.FilePath, project.RestoreMetadata.OutputPath);
-
-            return createdAssets?.Targets?.ToArray();
-        }
+        /// <returns>The assets file.</returns>
+        private LockFile? CreateAssetsFile(PackageSpec project) =>
+            this.assets.Create(project.FilePath, project.RestoreMetadata.OutputPath);
 
         /// <summary>
         /// Populates the collection of dependencies for a .NET project and framework combination.
         /// </summary>
-        /// <param name="framework">The .NET project and framework combination to analyze.</param>
         /// <param name="libraries">The collection of all libraries associated with the .NET project and framework
         /// combination.</param>
         private void PopulateDependencies(
-            TargetFrameworkInformation framework,
             IReadOnlyDictionary<string, LockFileTargetLibrary> libraries)
         {
-            foreach (var library in framework
-                .Dependencies
-                .Select(dependency => libraries.TryGetValue(dependency.Name, out var library) ? library : null)
-                .Where(library => library is not null))
+            foreach (var library in libraries.Values)
             {
                 this.RecordDependency(true, library!, libraries);
             }
@@ -170,6 +182,7 @@ namespace NuGetTransitiveDependencyFinder.ProjectAnalysis
         /// Finds the transitive NuGet dependencies by traversing the collection of dependencies previously recorded.
         /// </summary>
         /// <param name="framework">The .NET project and framework combination to analyze.</param>
+        /// <param name="dependencies">The project dependencies.</param>
         /// <param name="collateAllDependencies">A value indicating whether all dependencies, or merely those that are
         /// transitive, should be collated.</param>
         /// <param name="filter">An optional regular expression, to match certain dependencies. It will filter
@@ -177,10 +190,12 @@ namespace NuGetTransitiveDependencyFinder.ProjectAnalysis
         /// <see langword="true"/>.</param>
         /// <returns>The transitive NuGet dependency information, which can be processed for display.</returns>
         private Framework FindTransitiveDependencies(
-            TargetFrameworkInformation framework, bool collateAllDependencies, Regex? filter)
+            TargetFrameworkInformation framework,
+            IEnumerable<LockFileTargetLibrary> dependencies,
+            bool collateAllDependencies,
+            Regex? filter)
         {
-            foreach (var dependency in framework
-                .Dependencies
+            foreach (var dependency in dependencies
                 .Select(dependency =>
                     !string.Equals(dependency.Name, "NETStandard.Library", StringComparison.OrdinalIgnoreCase) &&
                     this.dependencies.TryGetValue(dependency.Name, out var value) ? value : null)


### PR DESCRIPTION
# Pull Request

## Summary

Without this change, only package references are considered. With this change, project references are considered as well.

Given the following example:

```
A
  -> B (project)
  -> C (project)
  -> X (package)

B
  -> C (project)
  -> X (package)

C
  -> X (package)
```

This fix now marks project C and package X as transitive when scanning project A, because it is also referenced by project B.

## Behavior

### Previous
Project references are ignored. 

### New
Project references are considered.

## Breaking Changes
No, the API remains the same.

## Testing Undertaken

Without fix:

```
Commencing analysis...
Microsoft (R) Build Engine version 16.11.1+3e40a09f8 for .NET
Copyright (C) Microsoft Corporation. All rights reserved.

  Determining projects to restore...
  Writing A/j2wlqag5.tis


  Determining projects to restore...
  All projects are up-to-date for restore.


  Determining projects to restore...
  All projects are up-to-date for restore.


  Determining projects to restore...
  All projects are up-to-date for restore.


A
    .NETCoreApp v5.0
        Newtonsoft.Json v12.0.3

B
    .NETCoreApp v5.0
        Newtonsoft.Json v12.0.3

C
    .NETCoreApp v5.0
        Newtonsoft.Json v12.0.3
```

With fix:

```
Microsoft (R) Build Engine version 16.11.1+3e40a09f8 for .NET
Copyright (C) Microsoft Corporation. All rights reserved.

  Determining projects to restore...
  Writing A/f21azqab.lil


  Determining projects to restore...
  All projects are up-to-date for restore.


  Determining projects to restore...
  All projects are up-to-date for restore.


  Determining projects to restore...
  All projects are up-to-date for restore.


A
    .NETCoreApp v5.0
        C v1.0.0 (Transitive)
        X v2.0.0 (Transitive)
        Newtonsoft.Json v12.0.3

B
    .NETCoreApp v5.0
        X v2.0.0 (Transitive)
        Newtonsoft.Json v12.0.3

C
    .NETCoreApp v5.0
        Newtonsoft.Json v12.0.3
```

## Additional Information
The assets file contains the information below, which `targetFramework.Dependencies` does not.

```json
{
  ..
  "projectFileDependencyGroups": {
    "net5.0": [
      "B >= 1.0.0",
      "C >= 1.0.0",
      "X >= 2.0.0"
    ]
  },
  ...
}
```

~Unfortunately, the dependencies listed in the assets file use a different framework notation (e.g. `.NETCoreApp,Version=v5.0` versus `net5.0`), so a translation is necessary. This mapping is not yet complete.~