### PR TITLE
Keep track of dependency providers

### DIFF
--- a/src/Product/NuGetTransitiveDependencyFinder.ConsoleApp/Output/DependencyWriter.cs
+++ b/src/Product/NuGetTransitiveDependencyFinder.ConsoleApp/Output/DependencyWriter.cs
@@ -27,6 +27,11 @@ namespace NuGetTransitiveDependencyFinder.ConsoleApp.Output
         private static readonly string DependencyPrefix = CreatePrefix(2);
 
         /// <summary>
+        /// The string prefix for each via dependency, which comprises three levels of indentation.
+        /// </summary>
+        private static readonly string ViaPrefix = CreatePrefix(3);
+
+        /// <summary>
         /// The logger object to which to write the output.
         /// </summary>
         private readonly ILogger<DependencyWriter> logger;
@@ -86,11 +91,15 @@ namespace NuGetTransitiveDependencyFinder.ConsoleApp.Output
                     this.logger.LogWarning(
                         DependencyPrefix +
                         string.Format(CultureInfo.CurrentCulture, Information.TransitiveDependency, dependency));
+
+                    foreach (var via in dependency.Via)
+                    {
+                        this.logger.LogDebug(ViaPrefix + via);
+                    }
                 }
                 else
                 {
-                    var dependencyString = dependency.ToString();
-                    this.logger.LogDebug(DependencyPrefix + dependencyString);
+                    this.logger.LogDebug(DependencyPrefix + dependency);
                 }
             }
         }

--- a/src/Product/NuGetTransitiveDependencyFinder/Output/Dependency.cs
+++ b/src/Product/NuGetTransitiveDependencyFinder/Output/Dependency.cs
@@ -6,6 +6,7 @@
 namespace NuGetTransitiveDependencyFinder.Output
 {
     using System;
+    using System.Collections.Generic;
     using NuGet.Versioning;
 
     /// <summary>
@@ -38,6 +39,7 @@ namespace NuGetTransitiveDependencyFinder.Output
         {
             this.Identifier = identifier;
             this.Version = version;
+            this.Via = new HashSet<Dependency>();
         }
 
         /// <summary>
@@ -49,6 +51,11 @@ namespace NuGetTransitiveDependencyFinder.Output
         /// Gets the dependency version.
         /// </summary>
         public NuGetVersion Version { get; }
+
+        /// <summary>
+        /// Gets the set of dependencies that provide this dependency.
+        /// </summary>
+        public ISet<Dependency> Via { get; }
 
         /// <summary>
         /// Gets a value indicating whether the dependency is a transitive dependency.

--- a/src/Product/NuGetTransitiveDependencyFinder/PublicAPI.Shipped.txt
+++ b/src/Product/NuGetTransitiveDependencyFinder/PublicAPI.Shipped.txt
@@ -14,6 +14,7 @@ NuGetTransitiveDependencyFinder.Output.Dependency.Equals(NuGetTransitiveDependen
 NuGetTransitiveDependencyFinder.Output.Dependency.Identifier.get -> string!
 NuGetTransitiveDependencyFinder.Output.Dependency.IsTransitive.get -> bool
 NuGetTransitiveDependencyFinder.Output.Dependency.Version.get -> NuGet.Versioning.NuGetVersion!
+NuGetTransitiveDependencyFinder.Output.Dependency.Via.get -> System.Collections.Generic.ISet<NuGetTransitiveDependencyFinder.Output.Dependency!>!
 NuGetTransitiveDependencyFinder.Output.Framework
 NuGetTransitiveDependencyFinder.Output.Framework.CompareTo(NuGetTransitiveDependencyFinder.Output.Framework? other) -> int
 NuGetTransitiveDependencyFinder.Output.Framework.CompareTo(object? obj) -> int


### PR DESCRIPTION
# Pull Request
This PR also includes #149, which is necessary for this to work.

## Summary
This fix keeps track of references to a dependency.

Given the following example:

```
A
  -> B (project)
  -> C (project)
  -> X (package)

B
  -> C (project)
  -> X (package)

C
  -> X (package)
```

When scanning project A, this fix:
- marks B as a 'provider' of C
- marks B and C as a 'provider' of X
- marks C and X as transitive

The logic for top-level dependencies has been slightly altered. This means that for a dependency to be transitive, it must have at least one 'provider'.

## Behavior

### Previous
Providers were not listed, and so were project dependencies.

### New
Providers are shown, and so are project dependencies.

## Breaking Changes
The public API contains a new method:

```diff
+NuGetTransitiveDependencyFinder.Output.Dependency.Via.get -> System.Collections.Generic.ISet<NuGetTransitiveDependencyFinder.Output.Dependency!>!
```

## Testing Undertaken

Without fix:

```
Commencing analysis...
Microsoft (R) Build Engine version 16.11.1+3e40a09f8 for .NET
Copyright (C) Microsoft Corporation. All rights reserved.

  Determining projects to restore...
  Writing A/j2wlqag5.tis


  Determining projects to restore...
  All projects are up-to-date for restore.


  Determining projects to restore...
  All projects are up-to-date for restore.


  Determining projects to restore...
  All projects are up-to-date for restore.


A
    .NETCoreApp v5.0
        Newtonsoft.Json v12.0.3

B
    .NETCoreApp v5.0
        Newtonsoft.Json v12.0.3

C
    .NETCoreApp v5.0
        Newtonsoft.Json v12.0.3
```

With fix (including #149):

```
Commencing analysis...
Microsoft (R) Build Engine version 16.11.1+3e40a09f8 for .NET
Copyright (C) Microsoft Corporation. All rights reserved.

  Determining projects to restore...
  Writing A/cd4k53de.v4n


  Determining projects to restore...
  All projects are up-to-date for restore.


  Determining projects to restore...
  All projects are up-to-date for restore.


  Determining projects to restore...
  All projects are up-to-date for restore.


A
    .NETCoreApp v5.0
        B v1.0.0
        C v1.0.0 (Transitive)
            B v1.0.0
        X v2.0.0 (Transitive)
            C v1.0.0
            B v1.0.0
        Newtonsoft.Json v12.0.3

B
    .NETCoreApp v5.0
        C v1.0.0
        X v2.0.0 (Transitive)
            C v1.0.0
        Newtonsoft.Json v12.0.3

C
    .NETCoreApp v5.0
        X v2.0.0
        Newtonsoft.Json v12.0.3
```

## Additional Information
Note that X is now correctly marked as a dependency of C. Before, it did not since X was a 'top-level' dependency and therefore never added to the list of dependencies.