### PR TITLE
Add metadata to pack as tool

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -215,7 +215,7 @@ jobs:
           $Extension = '${{ fromJson(env.extension)[steps.platform.outputs.platform] }}'
           $AssetName = "NuGetTransitiveDependencyFinder.ConsoleApp.${{ matrix.runtime }}$Extension"
           $AssetPath = '${{ github.workspace }}/src/Product/${{ env.project }}/bin/Release/net7.0/'
-          $AssetPath += "${{ matrix.runtime }}/publish/${{ env.project }}$Extension"
+          $AssetPath += "${{ matrix.runtime }}/publish/dotnet-transitive-dependency-finder$Extension"
           Write-Output -InputObject "::set-output name=asset_path::$AssetPath"
           Write-Output -InputObject "::set-output name=asset_name::$AssetName"
 

--- a/src/CodeAnalysisDictionary.xml
+++ b/src/CodeAnalysisDictionary.xml
@@ -9,6 +9,7 @@
       <Word>Async</Word>
       <Word>Comparer</Word>
       <Word>Deserialize</Word>
+      <Word>dotnet-transitive-dependency-finder</Word>
       <Word>Enum</Word>
       <Word>Finalizer</Word>
       <Word>formatter</Word>

--- a/src/Product/NuGetTransitiveDependencyFinder.ConsoleApp/NuGetTransitiveDependencyFinder.ConsoleApp.csproj
+++ b/src/Product/NuGetTransitiveDependencyFinder.ConsoleApp/NuGetTransitiveDependencyFinder.ConsoleApp.csproj
@@ -4,6 +4,19 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>dotnet-transitive-dependency-finder</ToolCommandName>
+    <AssemblyName>dotnet-transitive-dependency-finder</AssemblyName>
+    <Authors>Muiris Woulfe</Authors>
+    <Copyright>Copyright (c) Muiris Woulfe</Copyright>
+    <Description>The NuGet Transitive Dependency Finder analyzes .NET projects and solutions to find superfluous dependencies that have been explicitly added to projects. The goal is to simplify dependency management.</Description>
+    <PackageId>dotnet-transitive-dependency-finder-tool</PackageId>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/muiriswoulfe/NuGet-Transitive-Dependency-Finder</PackageProjectUrl>
+    <PackageReleaseNotes>See $(PackageProjectUrl)/releases for release notes.</PackageReleaseNotes>
+    <PackageVersion>$(VersionSuffix)</PackageVersion>
+    <RepositoryType>git</RepositoryType>
+    <RepositoryUrl>https://github.com/muiriswoulfe/NuGet-Transitive-Dependency-Finder.git</RepositoryUrl>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
# Pull Request

## Summary
This PR adds the metadata for distributing this application as a .NET tool: https://docs.microsoft.com/en-us/dotnet/core/tools/global-tools-how-to-create

If uploaded to NuGet, this allows one to use this application more easily, since it would then be installable using `dotnet tool install --global nugettransitivedependencyfinder.consoleapp` and usable with `dotnet transitive-dependency-finder`.

I did a suggestion for the CLI name, but let me know if I have to change something. I also added additional metadata based on [this](https://github.com/dotnet-outdated/dotnet-outdated/blob/master/src/DotNetOutdated/DotNetOutdated.csproj) project.

## Behavior
N/a

### Previous
N/a

### New
Package installs as a tool.

## Breaking Changes
N/a

## Testing Undertaken
N/a

## Additional Information
N/a