### PR TITLE
Updating .NET to v6.0.201

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,8 +43,6 @@ jobs:
           && env.SONAR_TOKEN != '' }}
         name: INITIALIZATION – .NET Install v5.0
         uses: actions/setup-dotnet@v2
-        with:
-          dotnet-version: 5.0.403
 
       # SonarCloud Initialization
       - env:
@@ -57,7 +55,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           distribution: zulu
-          java-version: 17.0.1
+          java-version: 17.0.2
 
       - env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,15 +35,6 @@ jobs:
       - name: INITIALIZATION – .NET Install
         uses: actions/setup-dotnet@v2
 
-      - env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        if: >-
-          ${{ matrix.configuration == 'Release'
-          && matrix.os == 'ubuntu-latest'
-          && env.SONAR_TOKEN != '' }}
-        name: INITIALIZATION – .NET Install v5.0
-        uses: actions/setup-dotnet@v2
-
       # SonarCloud Initialization
       - env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/global.json
+++ b/global.json
@@ -2,6 +2,6 @@
   "sdk": {
     "allowPrerelease": false,
     "rollForward": "latestMajor",
-    "version": "6.0.102"
+    "version": "6.0.201"
   }
 }


### PR DESCRIPTION
# Pull Request

<!-- Please provide as much detail as possible. Inapplicable sections may be
     left blank. -->

## Summary

Updating .NET to the latest release, v6.0.201.

This change also removes a superfluous installaton of .NET v5 for SonarQube, which was previously required for compatibility reasons. It also upgrades the version of Java used by SonarQube.