### PR TITLE
Updating .NET to v6.0.202

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: zulu
-          java-version: 17.0.2
+          java-version: 18.0.0
 
       - env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/global.json
+++ b/global.json
@@ -2,6 +2,6 @@
   "sdk": {
     "allowPrerelease": false,
     "rollForward": "latestMajor",
-    "version": "6.0.201"
+    "version": "6.0.202"
   }
 }


### PR DESCRIPTION
# Pull Request

## Summary

Updating .NET to the latest release, v6.0.202.

This change also updates the Java build dependency to the latest version, v18.0.0.