### PR TITLE
Updating .NET to v7.0.101

### DIFF
--- a/global.json
+++ b/global.json
@@ -2,6 +2,6 @@
   "sdk": {
     "allowPrerelease": false,
     "rollForward": "latestMajor",
-    "version": "7.0.100"
+    "version": "7.0.101"
   }
 }


### PR DESCRIPTION
Updating .NET from v7.0.100 to v7.0.101, following today's release.