### PR TITLE
XS✔ ◾ Adding Dependabot Build

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,7 @@
 # © Muiris Woulfe
 # Licensed under the MIT License
 
-*   @muiriswoulfe
+*                   @muiriswoulfe
+*.csproj            @muiriswoulfe @dependabot-bot
+*.props             @muiriswoulfe @dependabot-bot
+.github/workflows/  @muiriswoulfe @dependabot-bot

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,4 @@
 # © Muiris Woulfe
 # Licensed under the MIT License
 
-*                   @muiriswoulfe
-*.csproj            @muiriswoulfe @dependabot-bot
-*.props             @muiriswoulfe @dependabot-bot
-.github/workflows/  @muiriswoulfe @dependabot-bot
+*   @muiriswoulfe

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,7 @@ updates:
     open-pull-requests-limit: 100
     schedule:
       interval: daily
-      time: '00:00'
+      time: '00:00'                # yamllint disable-line rule:quoted-strings
       timezone: Universal
     labels:
       - dependencies
@@ -26,7 +26,7 @@ updates:
     open-pull-requests-limit: 100
     schedule:
       interval: daily
-      time: '00:00'
+      time: '00:00'                # yamllint disable-line rule:quoted-strings
       timezone: Universal
     labels:
       - dependencies

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,7 @@ updates:
     open-pull-requests-limit: 100
     schedule:
       interval: daily
-      time: 00:00
+      time: '00:00'
       timezone: Universal
     labels:
       - dependencies
@@ -26,7 +26,7 @@ updates:
     open-pull-requests-limit: 100
     schedule:
       interval: daily
-      time: 00:00
+      time: '00:00'
       timezone: Universal
     labels:
       - dependencies

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,11 @@ updates:
       interval: daily
     labels:
       - dependencies
+      - github-actions
+    assignees:
+      - muiriswoulfe
+    reviewers:
+      - muiriswoulfe
 
   - package-ecosystem: nuget
     directory: /
@@ -21,5 +26,10 @@ updates:
       interval: daily
     labels:
       - dependencies
+      - nuget
+    assignees:
+      - muiriswoulfe
+    reviewers:
+      - muiriswoulfe
 
 ...

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,10 +13,6 @@ updates:
       interval: daily
     labels:
       - dependencies
-    assignees:
-      - muiriswoulfe
-    reviewers:
-      - muiriswoulfe
 
   - package-ecosystem: nuget
     directory: /
@@ -25,9 +21,5 @@ updates:
       interval: daily
     labels:
       - dependencies
-    assignees:
-      - muiriswoulfe
-    reviewers:
-      - muiriswoulfe
 
 ...

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,8 @@ updates:
     open-pull-requests-limit: 100
     schedule:
       interval: daily
+      time: 00:00
+      timezone: Universal
     labels:
       - dependencies
       - github-actions
@@ -24,6 +26,8 @@ updates:
     open-pull-requests-limit: 100
     schedule:
       interval: daily
+      time: 00:00
+      timezone: Universal
     labels:
       - dependencies
       - nuget

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,32 @@
+# © Muiris Woulfe
+# Licensed under the MIT License
+
+---
+
+name: Dependabot
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependencies:
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    name: Dependabot
+    runs-on: ubuntu-latest
+    steps:
+      - name: Approve
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable Auto-Merge
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+...


### PR DESCRIPTION
# Pull Request

## Summary

Adding a Dependabot build for automatically approving and merging Dependabot pull requests, assuming the build completes successfully.

## Behavior

### Previous

Dependabot PRs had to be manually merged.

### New

Dependabot PRs will be automatically merged to `main` if the build completes.
