### PR TITLE
XS✔ ◾ Workflow: Fixing CodeQL & PR Metrics permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -454,7 +454,8 @@ jobs:
   validate-codeql:
     name: Validate – CodeQL
     runs-on: ubuntu-latest
-    permissions: {}
+    permissions:
+      security-events: write
     steps:
       # Initialization
       - name: INITIALIZATION – Checkout

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,9 @@ jobs:
   initialization:
     name: Initialization
     runs-on: ubuntu-latest
-    permissions: {}
+    permissions:
+      pull-requests: write
+      statuses: write
     steps:
       - name: INITIALIZATION – Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
# Pull Request

## Summary

Fixing CodeQL & PR Metrics permissions within build pipeline.

## Behavior

### Previous

In certain cases, CodeQL & PR Metrics had insufficient permissions and would fail to run successfully.

### New

CodeQL now has the following permissions and should always run successfully.

```YAML
security-events: write
```

PR Metrics now has the following permissions and should also always run successfully.

```YAML
pull-requests: write
statuses: write
```

## Breaking Changes

None.

## Testing Undertaken

Changes were successful run through the GitHub Actions pipelines.
