### PR TITLE
XS✔ ◾ Fixing Dependabot build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -497,6 +497,11 @@ jobs:
       contents: write
       pull-requests: write
     steps:
+      # Initialization
+      - name: INITIALIZATION – Checkout
+        uses: actions/checkout@v3
+
+      # PR
       - name: PR – Approve
         shell: pwsh
         run: gh pr review --approve "$PR_URL"


### PR DESCRIPTION
# Pull Request

## Summary

Updating the Dependabot-only build to auto-merge Dependabot PRs where possible.

## Behavior

### Previous

Dependabot build would fail, claiming that it was not running as part of a Git repo.

### New

Dependabot build should succeed as Git code is checked out.