### PR TITLE
XS✔ ◾ xUnit: Refining test discoverers

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "dotnet.defaultSolution": "NuGetTransitiveDependencyFinder.sln"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "dotnet.defaultSolution": "NuGetTransitiveDependencyFinder.sln"
-}

--- a/src/Tests/NuGetTransitiveDependencyFinder.TestUtilities/Globalization/AllCulturesBaseAttributeDiscoverer.cs
+++ b/src/Tests/NuGetTransitiveDependencyFinder.TestUtilities/Globalization/AllCulturesBaseAttributeDiscoverer.cs
@@ -36,21 +36,18 @@ internal static class AllCulturesBaseAttributeDiscoverer
     /// <param name="diagnosticMessageSink">The message sink that receives the test result messages.</param>
     /// <param name="discoveryOptions">The discovery options to use.</param>
     /// <param name="testMethod">The test method to which the current test case belongs.</param>
-    /// <param name="dataRow">The row of data for the test case.</param>
     /// <returns>The full suite of test cases to run.</returns>
     public static IEnumerable<IXunitTestCase> CreateFactTestCases(
         IMessageSink diagnosticMessageSink,
         ITestFrameworkDiscoveryOptions discoveryOptions,
-        ITestMethod testMethod,
-        object[]? dataRow = null) =>
+        ITestMethod testMethod) =>
         AllCultures.Select(
             culture => new AllCulturesFactTestCase(
                 diagnosticMessageSink,
                 discoveryOptions.MethodDisplayOrDefault(),
                 discoveryOptions.MethodDisplayOptionsOrDefault(),
                 testMethod,
-                culture,
-                dataRow));
+                culture));
 
     /// <summary>
     /// Creates the full suite of test cases, where each test case validates a single culture, with each test case

--- a/src/Tests/NuGetTransitiveDependencyFinder.TestUtilities/Globalization/AllCulturesBaseTestCase.cs
+++ b/src/Tests/NuGetTransitiveDependencyFinder.TestUtilities/Globalization/AllCulturesBaseTestCase.cs
@@ -58,7 +58,7 @@ internal static class AllCulturesBaseTestCase
             CultureInfo.CurrentCulture = culture;
             CultureInfo.CurrentUICulture = culture;
 
-            return await baseRunAsyncFunction().ConfigureAwait(false);
+            return await baseRunAsyncFunction();
         }
         finally
         {

--- a/src/Tests/NuGetTransitiveDependencyFinder.TestUtilities/Globalization/AllCulturesFactAttribute.cs
+++ b/src/Tests/NuGetTransitiveDependencyFinder.TestUtilities/Globalization/AllCulturesFactAttribute.cs
@@ -6,7 +6,6 @@
 namespace NuGetTransitiveDependencyFinder.TestUtilities.Globalization;
 
 using System;
-using System.Runtime.CompilerServices;
 using Xunit;
 using Xunit.Sdk;
 
@@ -18,5 +17,4 @@ using Xunit.Sdk;
 [XunitTestCaseDiscoverer("Xunit.Sdk.TheoryDiscoverer", "xunit.execution.{Platform}")]
 public sealed class AllCulturesFactAttribute : FactAttribute
 {
-    public AllCulturesFactAttribute([CallerMemberName] string displayName = "") => this.DisplayName = displayName;
 }

--- a/src/Tests/NuGetTransitiveDependencyFinder.TestUtilities/Globalization/AllCulturesFactAttribute.cs
+++ b/src/Tests/NuGetTransitiveDependencyFinder.TestUtilities/Globalization/AllCulturesFactAttribute.cs
@@ -14,7 +14,7 @@ using Xunit.Sdk;
 /// within the system running the tests.
 /// </summary>
 [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
-[XunitTestCaseDiscoverer("Xunit.Sdk.TheoryDiscoverer", "xunit.execution.{Platform}")]
+[XunitTestCaseDiscoverer("Xunit.Sdk.FactDiscoverer", "xunit.execution.{Platform}")]
 public sealed class AllCulturesFactAttribute : FactAttribute
 {
 }

--- a/src/Tests/NuGetTransitiveDependencyFinder.TestUtilities/Globalization/AllCulturesFactAttribute.cs
+++ b/src/Tests/NuGetTransitiveDependencyFinder.TestUtilities/Globalization/AllCulturesFactAttribute.cs
@@ -5,6 +5,8 @@
 
 namespace NuGetTransitiveDependencyFinder.TestUtilities.Globalization;
 
+using System;
+using System.Runtime.CompilerServices;
 using Xunit;
 using Xunit.Sdk;
 
@@ -12,9 +14,9 @@ using Xunit.Sdk;
 /// An attribute whose application to an xUnit.net fact test will result in that test being run for all cultures present
 /// within the system running the tests.
 /// </summary>
-[XunitTestCaseDiscoverer(
-    "NuGetTransitiveDependencyFinder.TestUtilities.Globalization.AllCulturesFactAttributeDiscoverer",
-    "NuGetTransitiveDependencyFinder.TestUtilities")]
+[AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+[XunitTestCaseDiscoverer("Xunit.Sdk.TheoryDiscoverer", "xunit.execution.{Platform}")]
 public sealed class AllCulturesFactAttribute : FactAttribute
 {
+    public AllCulturesFactAttribute([CallerMemberName] string displayName = "") => this.DisplayName = displayName;
 }

--- a/src/Tests/NuGetTransitiveDependencyFinder.TestUtilities/Globalization/AllCulturesFactAttributeDiscoverer.cs
+++ b/src/Tests/NuGetTransitiveDependencyFinder.TestUtilities/Globalization/AllCulturesFactAttributeDiscoverer.cs
@@ -6,7 +6,6 @@
 namespace NuGetTransitiveDependencyFinder.TestUtilities.Globalization;
 
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using Xunit.Abstractions;
 using Xunit.Sdk;
 
@@ -14,23 +13,16 @@ using Xunit.Sdk;
 /// An attribute discoverer, for applying all cultures to xUnit.net tests marked with
 /// <see cref="AllCulturesFactAttribute"/>.
 /// </summary>
-[SuppressMessage(
-    "Microsoft.Performance",
-    "CA1812:AvoidUninstantiatedInternalClasses",
-    Justification = "Instantiated via reflection.")]
-internal class AllCulturesFactAttributeDiscoverer : IXunitTestCaseDiscoverer
+internal class AllCulturesFactAttributeDiscoverer : FactDiscoverer
 {
-    /// <summary>
-    /// The message sink that receives the test result messages.
-    /// </summary>
-    private readonly IMessageSink diagnosticMessageSink;
-
     /// <summary>
     /// Initializes a new instance of the <see cref="AllCulturesFactAttributeDiscoverer"/> class.
     /// </summary>
     /// <param name="diagnosticMessageSink">The message sink that receives the test result messages.</param>
-    public AllCulturesFactAttributeDiscoverer(IMessageSink diagnosticMessageSink) =>
-        this.diagnosticMessageSink = diagnosticMessageSink;
+    public AllCulturesFactAttributeDiscoverer(IMessageSink diagnosticMessageSink)
+        : base(diagnosticMessageSink)
+    {
+    }
 
     /// <summary>
     /// Discovers the full suite of test cases, where each test case validates a single culture, corresponding to each
@@ -40,12 +32,12 @@ internal class AllCulturesFactAttributeDiscoverer : IXunitTestCaseDiscoverer
     /// <param name="testMethod">The test method to which the current test case belongs.</param>
     /// <param name="factAttribute">The fact attribute attached to the test method.</param>
     /// <returns>The full suite of test cases to run.</returns>
-    public IEnumerable<IXunitTestCase> Discover(
+    public override IEnumerable<IXunitTestCase> Discover(
         ITestFrameworkDiscoveryOptions discoveryOptions,
         ITestMethod testMethod,
         IAttributeInfo factAttribute) =>
         AllCulturesBaseAttributeDiscoverer.CreateFactTestCases(
-            this.diagnosticMessageSink,
+            this.DiagnosticMessageSink,
             discoveryOptions,
             testMethod);
 }

--- a/src/Tests/NuGetTransitiveDependencyFinder.TestUtilities/Globalization/AllCulturesFactTestCase.cs
+++ b/src/Tests/NuGetTransitiveDependencyFinder.TestUtilities/Globalization/AllCulturesFactTestCase.cs
@@ -46,20 +46,13 @@ internal class AllCulturesFactTestCase : XunitTestCase
     /// has been performed.</param>
     /// <param name="testMethod">The test method to which the current test case belongs.</param>
     /// <param name="culture">The culture for which to run the current test.</param>
-    /// <param name="testMethodArguments">The arguments for the test method.</param>
     public AllCulturesFactTestCase(
         IMessageSink diagnosticMessageSink,
         TestMethodDisplay defaultMethodDisplay,
         TestMethodDisplayOptions defaultMethodDisplayOptions,
         ITestMethod testMethod,
-        CultureInfo culture,
-        object[]? testMethodArguments = null)
-        : base(
-            diagnosticMessageSink,
-            defaultMethodDisplay,
-            defaultMethodDisplayOptions,
-            testMethod,
-            testMethodArguments) =>
+        CultureInfo culture)
+        : base(diagnosticMessageSink, defaultMethodDisplay, defaultMethodDisplayOptions, testMethod) =>
         this.Initialize(culture);
 
     /// <summary>

--- a/src/Tests/NuGetTransitiveDependencyFinder.TestUtilities/Globalization/AllCulturesTheoryAttribute.cs
+++ b/src/Tests/NuGetTransitiveDependencyFinder.TestUtilities/Globalization/AllCulturesTheoryAttribute.cs
@@ -5,6 +5,8 @@
 
 namespace NuGetTransitiveDependencyFinder.TestUtilities.Globalization;
 
+using System;
+using System.Runtime.CompilerServices;
 using Xunit;
 using Xunit.Sdk;
 
@@ -12,9 +14,9 @@ using Xunit.Sdk;
 /// An attribute whose application to an xUnit.net theory test will result in that test being run for all cultures
 /// present within the system running the tests.
 /// </summary>
-[XunitTestCaseDiscoverer(
-    "NuGetTransitiveDependencyFinder.TestUtilities.Globalization.AllCulturesTheoryAttributeDiscoverer",
-    "NuGetTransitiveDependencyFinder.TestUtilities")]
+[AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+[XunitTestCaseDiscoverer("Xunit.Sdk.TheoryDiscoverer", "xunit.execution.{Platform}")]
 public sealed class AllCulturesTheoryAttribute : TheoryAttribute
 {
+    public AllCulturesTheoryAttribute([CallerMemberName] string displayName = "") => this.DisplayName = displayName;
 }

--- a/src/Tests/NuGetTransitiveDependencyFinder.TestUtilities/Globalization/AllCulturesTheoryAttribute.cs
+++ b/src/Tests/NuGetTransitiveDependencyFinder.TestUtilities/Globalization/AllCulturesTheoryAttribute.cs
@@ -6,7 +6,6 @@
 namespace NuGetTransitiveDependencyFinder.TestUtilities.Globalization;
 
 using System;
-using System.Runtime.CompilerServices;
 using Xunit;
 using Xunit.Sdk;
 
@@ -18,5 +17,4 @@ using Xunit.Sdk;
 [XunitTestCaseDiscoverer("Xunit.Sdk.TheoryDiscoverer", "xunit.execution.{Platform}")]
 public sealed class AllCulturesTheoryAttribute : TheoryAttribute
 {
-    public AllCulturesTheoryAttribute([CallerMemberName] string displayName = "") => this.DisplayName = displayName;
 }

--- a/src/Tests/NuGetTransitiveDependencyFinder.TestUtilities/Globalization/AllCulturesTheoryAttributeDiscoverer.cs
+++ b/src/Tests/NuGetTransitiveDependencyFinder.TestUtilities/Globalization/AllCulturesTheoryAttributeDiscoverer.cs
@@ -6,7 +6,6 @@
 namespace NuGetTransitiveDependencyFinder.TestUtilities.Globalization;
 
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using Xunit.Abstractions;
 using Xunit.Sdk;
 
@@ -14,10 +13,6 @@ using Xunit.Sdk;
 /// An attribute discoverer, for applying all cultures to xUnit.net tests marked with
 /// <see cref="AllCulturesTheoryAttribute"/>.
 /// </summary>
-[SuppressMessage(
-    "Microsoft.Performance",
-    "CA1812:AvoidUninstantiatedInternalClasses",
-    Justification = "Instantiated via reflection.")]
 internal class AllCulturesTheoryAttributeDiscoverer : TheoryDiscoverer
 {
     /// <summary>
@@ -30,33 +25,14 @@ internal class AllCulturesTheoryAttributeDiscoverer : TheoryDiscoverer
     }
 
     /// <summary>
-    /// Creates test cases for a single row of data.
-    /// </summary>
-    /// <param name="discoveryOptions">The discovery options to use.</param>
-    /// <param name="testMethod">The test method to which the current test case belongs.</param>
-    /// <param name="theoryAttribute">The theory attribute attached to the test method.</param>
-    /// <param name="dataRow">The row of data for the test case.</param>
-    /// <returns>The test case to run.</returns>
-    protected override IEnumerable<IXunitTestCase> CreateTestCasesForDataRow(
-        ITestFrameworkDiscoveryOptions discoveryOptions,
-        ITestMethod testMethod,
-        IAttributeInfo theoryAttribute,
-        object[] dataRow) =>
-        AllCulturesBaseAttributeDiscoverer.CreateFactTestCases(
-            this.DiagnosticMessageSink,
-            discoveryOptions,
-            testMethod,
-            dataRow);
-
-    /// <summary>
-    /// Creates test cases for the entire theory. This is used when one or more of the theory data items are not
-    /// serializable or when theory pre-enumeration skipping has been requested.
+    /// Discovers the full suite of test cases, where each test case validates a single culture, corresponding to each
+    /// test method marked with <see cref="AllCulturesTheoryAttribute"/>.
     /// </summary>
     /// <param name="discoveryOptions">The discovery options to use.</param>
     /// <param name="testMethod">The test method to which the current test case belongs.</param>
     /// <param name="theoryAttribute">The theory attribute attached to the test method.</param>
     /// <returns>The full suite of test cases to run.</returns>
-    protected override IEnumerable<IXunitTestCase> CreateTestCasesForTheory(
+    public override IEnumerable<IXunitTestCase> Discover(
         ITestFrameworkDiscoveryOptions discoveryOptions,
         ITestMethod testMethod,
         IAttributeInfo theoryAttribute) =>

--- a/src/Tests/NuGetTransitiveDependencyFinder.UnitTests/Utilities/NuGetLoggerUnitTests.cs
+++ b/src/Tests/NuGetTransitiveDependencyFinder.UnitTests/Utilities/NuGetLoggerUnitTests.cs
@@ -198,7 +198,7 @@ public class NuGetLoggerUnitTests
         LogLevel expectedLogLevel)
     {
         // Act
-        await this.nuGetLogger.LogAsync(CreateLogMessage(inputLogLevel)).ConfigureAwait(false);
+        await this.nuGetLogger.LogAsync(CreateLogMessage(inputLogLevel));
 
         // Assert
         _ = this.loggerMock.Entries
@@ -224,7 +224,7 @@ public class NuGetLoggerUnitTests
         // Act
         foreach (var value in values)
         {
-            await this.nuGetLogger.LogAsync(CreateLogMessage(value)).ConfigureAwait(false);
+            await this.nuGetLogger.LogAsync(CreateLogMessage(value));
         }
 
         // Assert
@@ -254,7 +254,7 @@ public class NuGetLoggerUnitTests
         LogLevel expectedLogLevel)
     {
         // Act
-        await this.nuGetLogger.LogAsync(inputLogLevel, TestMessage).ConfigureAwait(false);
+        await this.nuGetLogger.LogAsync(inputLogLevel, TestMessage);
 
         // Assert
         _ = this.loggerMock.Entries
@@ -280,7 +280,7 @@ public class NuGetLoggerUnitTests
         // Act
         foreach (var value in values)
         {
-            await this.nuGetLogger.LogAsync(value, TestMessage).ConfigureAwait(false);
+            await this.nuGetLogger.LogAsync(value, TestMessage);
         }
 
         // Assert


### PR DESCRIPTION
# Pull Request

## Summary

Refining the design of the xUnit test discoverers to reflect best practices and ensure all requirements for the test discoverers are met.

Partially addresses issue #29.

## Behavior

### Previous

All tests would run, but "dotnet test -t" would not list tests in assemblies with the custom test attributes, which made testing using IDEs difficult.

### New

All tests run and "dotnet test -t" lists all tests. In addition, more modern practices have been employed, with redundant logic removed.

## Breaking Changes

None

## Testing Undertaken

Tests discovered locally via "dotnet test -t" and then run. Tests also run through GitHub Actions.