### PR TITLE
XS✔ ◾ Updating Dockerfile to .NET 8.0

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,2 +1,2 @@
-ARG VARIANT=latest
+ARG VARIANT=8.0-bookworm-slim
 FROM mcr.microsoft.com/dotnet/sdk:${VARIANT}

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,2 +1,2 @@
-ARG VARIANT=7.0-bullseye-slim
+ARG VARIANT=latest
 FROM mcr.microsoft.com/dotnet/sdk:${VARIANT}

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,2 +1,2 @@
-ARG VARIANT=8.0-bookworm-slim
+ARG VARIANT=latest
 FROM mcr.microsoft.com/dotnet/sdk:${VARIANT}


### PR DESCRIPTION
# Pull Request

## Summary

Updating Dockerfile for Github Codespaces to .NET 8.0.

## Behavior

### Previous

The Dockerfile specified .NET 7.0.

### New

The Dockerfile now specifies .NET 8.0.