### PR TITLE
XS✔ ◾ Updating .NET to v8.0.403

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -430,7 +430,10 @@ jobs:
   validate-lint:
     name: Validate – Lint
     runs-on: ubuntu-latest
-    permissions: {}
+    permissions:
+      contents: read
+      packages: read
+      statuses: write
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1

--- a/global.json
+++ b/global.json
@@ -2,6 +2,6 @@
   "sdk": {
     "allowPrerelease": false,
     "rollForward": "latestMajor",
-    "version": "8.0.403"
+    "version": "8.0.401"
   }
 }

--- a/global.json
+++ b/global.json
@@ -2,6 +2,6 @@
   "sdk": {
     "allowPrerelease": false,
     "rollForward": "latestMajor",
-    "version": "8.0.401"
+    "version": "8.0.403"
   }
 }


### PR DESCRIPTION
This pull request includes a change to the GitHub Actions workflow configuration to adjust permissions for the `validate-lint` job.

Permissions adjustment:

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L433-R436): Modified the `permissions` for the `validate-lint` job to include `contents: read`, `packages: read`, and `statuses: write`.