### PR TITLE
XS✔ ◾ .NET 9 Update – Part 2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -243,7 +243,7 @@ jobs:
         run: |-
           $Extension = '${{ fromJson(env.extension)[steps.platform.outputs.PLATFORM] }}'
           $AssetName = "NuGetTransitiveDependencyFinder.ConsoleApp.${{ matrix.runtime }}$Extension"
-          $AssetPath = '${{ github.workspace }}/src/Product/${{ env.project }}/bin/Release/net8.0/'
+          $AssetPath = '${{ github.workspace }}/src/Product/${{ env.project }}/bin/Release/net9.0/'
           $AssetPath += "${{ matrix.runtime }}/publish/dotnet-transitive-dependency-finder$Extension"
           Write-Output -InputObject "ASSET_PATH=$AssetPath" >> $Env:GITHUB_OUTPUT
           Write-Output -InputObject "ASSET_NAME=$AssetName" >> $Env:GITHUB_OUTPUT

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -182,7 +182,7 @@ jobs:
         run: |-
           $Extension = '${{ fromJson(env.extension)[steps.platform.outputs.PLATFORM] }}'
           $AssetName = "NuGetTransitiveDependencyFinder.ConsoleApp.${{ matrix.runtime }}$Extension"
-          $AssetPath = '${{ github.workspace }}/src/${{ env.project }}/bin/Release/net8.0/'
+          $AssetPath = '${{ github.workspace }}/src/${{ env.project }}/bin/Release/net9.0/'
           $AssetPath += "${{ matrix.runtime }}/publish/${{ env.project }}$Extension"
           Write-Output -InputObject "ASSET_NAME=$AssetName" >> $Env:GITHUB_OUTPUT
           Write-Output -InputObject "ASSET_PATH=$AssetPath" >> $Env:GITHUB_OUTPUT

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,7 +6,7 @@
       "type": "coreclr",
       "request": "launch",
       "preLaunchTask": "Build Debug",
-      "program": "${workspaceFolder}/src/Product/NuGetTransitiveDependencyFinder.ConsoleApp/bin/Debug/net8.0/NuGetTransitiveDependencyFinder.ConsoleApp.dll",
+      "program": "${workspaceFolder}/src/Product/NuGetTransitiveDependencyFinder.ConsoleApp/bin/Debug/net9.0/NuGetTransitiveDependencyFinder.ConsoleApp.dll",
       "args": [
         "--projectOrSolution",
         "${workspaceFolder}/NuGetTransitiveDependencyFinder.sln"
@@ -18,7 +18,7 @@
       "type": "coreclr",
       "request": "launch",
       "preLaunchTask": "Build Debug",
-      "program": "${workspaceFolder}/src/Product/NuGetTransitiveDependencyFinder.ConsoleApp/bin/Debug/net8.0/NuGetTransitiveDependencyFinder.ConsoleApp.dll",
+      "program": "${workspaceFolder}/src/Product/NuGetTransitiveDependencyFinder.ConsoleApp/bin/Debug/net9.0/NuGetTransitiveDependencyFinder.ConsoleApp.dll",
       "args": [
         "--projectOrSolution",
         "${workspaceFolder}/NuGetTransitiveDependencyFinder.sln",
@@ -32,7 +32,7 @@
       "type": "coreclr",
       "request": "launch",
       "preLaunchTask": "Build Debug",
-      "program": "${workspaceFolder}/src/Product/NuGetTransitiveDependencyFinder.ConsoleApp/bin/Debug/net8.0/NuGetTransitiveDependencyFinder.ConsoleApp.dll",
+      "program": "${workspaceFolder}/src/Product/NuGetTransitiveDependencyFinder.ConsoleApp/bin/Debug/net9.0/NuGetTransitiveDependencyFinder.ConsoleApp.dll",
       "args": ["--help"],
       "cwd": "${workspaceFolder}"
     },
@@ -41,7 +41,7 @@
       "type": "coreclr",
       "request": "launch",
       "preLaunchTask": "Build Debug",
-      "program": "${workspaceFolder}/src/Product/NuGetTransitiveDependencyFinder.ConsoleApp/bin/Debug/net8.0/NuGetTransitiveDependencyFinder.ConsoleApp.dll",
+      "program": "${workspaceFolder}/src/Product/NuGetTransitiveDependencyFinder.ConsoleApp/bin/Debug/net9.0/NuGetTransitiveDependencyFinder.ConsoleApp.dll",
       "args": ["--version"],
       "cwd": "${workspaceFolder}"
     },
@@ -50,7 +50,7 @@
       "type": "coreclr",
       "request": "launch",
       "preLaunchTask": "Build Release",
-      "program": "${workspaceFolder}/src/Product/NuGetTransitiveDependencyFinder.ConsoleApp/bin/Release/net8.0/NuGetTransitiveDependencyFinder.ConsoleApp.dll",
+      "program": "${workspaceFolder}/src/Product/NuGetTransitiveDependencyFinder.ConsoleApp/bin/Release/net9.0/NuGetTransitiveDependencyFinder.ConsoleApp.dll",
       "args": [
         "--projectOrSolution",
         "${workspaceFolder}/NuGetTransitiveDependencyFinder.sln"
@@ -62,7 +62,7 @@
       "type": "coreclr",
       "request": "launch",
       "preLaunchTask": "Build Debug",
-      "program": "${workspaceFolder}/src/Product/NuGetTransitiveDependencyFinder.ConsoleApp/bin/Debug/net8.0/NuGetTransitiveDependencyFinder.ConsoleApp.dll",
+      "program": "${workspaceFolder}/src/Product/NuGetTransitiveDependencyFinder.ConsoleApp/bin/Debug/net9.0/NuGetTransitiveDependencyFinder.ConsoleApp.dll",
       "args": [
         "--projectOrSolution",
         "${workspaceFolder}/NuGetTransitiveDependencyFinder.sln"
@@ -75,7 +75,7 @@
       "type": "coreclr",
       "request": "launch",
       "preLaunchTask": "Build Debug",
-      "program": "${workspaceFolder}/src/Product/NuGetTransitiveDependencyFinder.ConsoleApp/bin/Debug/net8.0/NuGetTransitiveDependencyFinder.ConsoleApp.dll",
+      "program": "${workspaceFolder}/src/Product/NuGetTransitiveDependencyFinder.ConsoleApp/bin/Debug/net9.0/NuGetTransitiveDependencyFinder.ConsoleApp.dll",
       "args": [
         "--projectOrSolution",
         "${workspaceFolder}/NuGetTransitiveDependencyFinder.sln",
@@ -89,7 +89,7 @@
       "type": "coreclr",
       "request": "launch",
       "preLaunchTask": "Build Debug",
-      "program": "${workspaceFolder}/src/Product/NuGetTransitiveDependencyFinder.ConsoleApp/bin/Debug/net8.0/NuGetTransitiveDependencyFinder.ConsoleApp.dll",
+      "program": "${workspaceFolder}/src/Product/NuGetTransitiveDependencyFinder.ConsoleApp/bin/Debug/net9.0/NuGetTransitiveDependencyFinder.ConsoleApp.dll",
       "args": ["--help"],
       "cwd": "${workspaceFolder}",
       "console": "externalTerminal"
@@ -99,7 +99,7 @@
       "type": "coreclr",
       "request": "launch",
       "preLaunchTask": "Build Debug",
-      "program": "${workspaceFolder}/src/Product/NuGetTransitiveDependencyFinder.ConsoleApp/bin/Debug/net8.0/NuGetTransitiveDependencyFinder.ConsoleApp.dll",
+      "program": "${workspaceFolder}/src/Product/NuGetTransitiveDependencyFinder.ConsoleApp/bin/Debug/net9.0/NuGetTransitiveDependencyFinder.ConsoleApp.dll",
       "args": ["--version"],
       "cwd": "${workspaceFolder}",
       "console": "externalTerminal"
@@ -109,7 +109,7 @@
       "type": "coreclr",
       "request": "launch",
       "preLaunchTask": "Build Release",
-      "program": "${workspaceFolder}/src/Product/NuGetTransitiveDependencyFinder.ConsoleApp/bin/Release/net8.0/NuGetTransitiveDependencyFinder.ConsoleApp.dll",
+      "program": "${workspaceFolder}/src/Product/NuGetTransitiveDependencyFinder.ConsoleApp/bin/Release/net9.0/NuGetTransitiveDependencyFinder.ConsoleApp.dll",
       "args": [
         "--projectOrSolution",
         "${workspaceFolder}/NuGetTransitiveDependencyFinder.sln"

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -15,7 +15,7 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <SignAssembly>true</SignAssembly>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 

--- a/src/TestCollateral/NoTransitiveDependencies/NoTransitiveDependencies.csproj
+++ b/src/TestCollateral/NoTransitiveDependencies/NoTransitiveDependencies.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
# Pull Request

## Summary

This updates various configuration files to change the target framework from .NET 8.0 to .NET 9.0. The changes affect build, release, and launch configurations.

Key changes include:

### Build and Release Configuration Updates

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L246-R246): Updated the `AssetPath` to use `net9.0` instead of `net8.0`.
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L185-R185): Updated the `AssetPath` to use `net9.0` instead of `net8.0`.

### Launch Configuration Updates

* [`.vscode/launch.json`](diffhunk://#diff-bd5430ee7c51dc892a67b3f2829d1f5b6d223f0fd48b82322cfd45baf9f5e945L9-R9): Updated multiple entries to use `net9.0` instead of `net8.0` for the `program` path. [[1]](diffhunk://#diff-bd5430ee7c51dc892a67b3f2829d1f5b6d223f0fd48b82322cfd45baf9f5e945L9-R9) [[2]](diffhunk://#diff-bd5430ee7c51dc892a67b3f2829d1f5b6d223f0fd48b82322cfd45baf9f5e945L21-R21) [[3]](diffhunk://#diff-bd5430ee7c51dc892a67b3f2829d1f5b6d223f0fd48b82322cfd45baf9f5e945L35-R35) [[4]](diffhunk://#diff-bd5430ee7c51dc892a67b3f2829d1f5b6d223f0fd48b82322cfd45baf9f5e945L44-R44) [[5]](diffhunk://#diff-bd5430ee7c51dc892a67b3f2829d1f5b6d223f0fd48b82322cfd45baf9f5e945L53-R53) [[6]](diffhunk://#diff-bd5430ee7c51dc892a67b3f2829d1f5b6d223f0fd48b82322cfd45baf9f5e945L65-R65) [[7]](diffhunk://#diff-bd5430ee7c51dc892a67b3f2829d1f5b6d223f0fd48b82322cfd45baf9f5e945L78-R78) [[8]](diffhunk://#diff-bd5430ee7c51dc892a67b3f2829d1f5b6d223f0fd48b82322cfd45baf9f5e945L92-R92) [[9]](diffhunk://#diff-bd5430ee7c51dc892a67b3f2829d1f5b6d223f0fd48b82322cfd45baf9f5e945L102-R102) [[10]](diffhunk://#diff-bd5430ee7c51dc892a67b3f2829d1f5b6d223f0fd48b82322cfd45baf9f5e945L112-R112)

### Project File Updates

* [`src/Directory.Build.props`](diffhunk://#diff-5c1900dca99df01c3ddc3a884282164b04deee76e79b176e2d34cfa47f3b8907L18-R18): Changed the `TargetFramework` from `net8.0` to `net9.0`.
* [`src/TestCollateral/NoTransitiveDependencies/NoTransitiveDependencies.csproj`](diffhunk://#diff-8963a3abd5880e9b51de2d2abac26ce69b843682d03a09a9a07d88797156f064L7-R7): Changed the `TargetFramework` from `net8.0` to `net9.0`.
