### PR TITLE
XS✔ ◾ .NET 9 – Code Modernization

### DIFF
--- a/src/UnitTests/NuGetTransitiveDependencyFinder.UnitTests.ConsoleApp/Process/ProgramRunnerUnitTests.cs
+++ b/src/UnitTests/NuGetTransitiveDependencyFinder.UnitTests.ConsoleApp/Process/ProgramRunnerUnitTests.cs
@@ -44,6 +44,12 @@ public partial class ProgramRunnerUnitTests
     private readonly Mock<ITransitiveDependencyFinder> transitiveDependencyFinder = new();
 
     /// <summary>
+    /// Gets the filter regular expression for use within the unit tests.
+    /// </summary>
+    [GeneratedRegex("Filter")]
+    private static partial Regex FilterRegex { get; }
+
+    /// <summary>
     /// Tests that when <see cref="ProgramRunner.Run()"/> is called, it performs the expected actions.
     /// </summary>
     [AllCulturesFact]
@@ -59,9 +65,9 @@ public partial class ProgramRunnerUnitTests
             .Returns(true);
         _ = this.commandLineOptions
             .SetupGet(mock => mock.Filter)
-            .Returns(FilterRegex());
+            .Returns(FilterRegex);
         _ = this.transitiveDependencyFinder
-            .Setup(mock => mock.Run("ProjectOrSolution", true, FilterRegex()))
+            .Setup(mock => mock.Run("ProjectOrSolution", true, FilterRegex))
             .Returns(projects);
         var programRunner = new ProgramRunner(
             this.commandLineOptions.Object,
@@ -83,16 +89,9 @@ public partial class ProgramRunnerUnitTests
         this.commandLineOptions.VerifyGet(mock => mock.All, Times.Once);
         this.commandLineOptions.VerifyGet(mock => mock.Filter, Times.Once);
         this.commandLineOptions.VerifyNoOtherCalls();
-        this.transitiveDependencyFinder.Verify(mock => mock.Run("ProjectOrSolution", true, FilterRegex()), Times.Once);
+        this.transitiveDependencyFinder.Verify(mock => mock.Run("ProjectOrSolution", true, FilterRegex), Times.Once);
         this.transitiveDependencyFinder.VerifyNoOtherCalls();
         this.dependencyWriter.Verify(mock => mock.Write(projects), Times.Once);
         this.dependencyWriter.VerifyNoOtherCalls();
     }
-
-    /// <summary>
-    /// The filter regular expression for use within the unit tests.
-    /// </summary>
-    /// <returns>The filter regular expression.</returns>
-    [GeneratedRegex("Filter")]
-    private static partial Regex FilterRegex();
 }

--- a/src/UnitTests/NuGetTransitiveDependencyFinder.UnitTests/ProjectAnalysis/DependencyFinderTests.cs
+++ b/src/UnitTests/NuGetTransitiveDependencyFinder.UnitTests/ProjectAnalysis/DependencyFinderTests.cs
@@ -270,7 +270,7 @@ public partial class DependencyFinderTests
         _ = this.assetsMock.Setup(mock => mock.Create(filePath, outputPath)).Returns(lockFile);
 
         // Act
-        var result = this.dependencyFinder.Run(projectOrSolutionPath, false, MatchingProjectsRegex());
+        var result = this.dependencyFinder.Run(projectOrSolutionPath, false, MatchingProjectsRegex);
 
         // Assert
         _ = result.HasChildren
@@ -338,7 +338,7 @@ public partial class DependencyFinderTests
         _ = this.assetsMock.Setup(mock => mock.Create(filePath, outputPath)).Returns(lockFile);
 
         // Act
-        var result = this.dependencyFinder.Run(projectOrSolutionPath, false, MatchingProjectsRegex());
+        var result = this.dependencyFinder.Run(projectOrSolutionPath, false, MatchingProjectsRegex);
 
         // Assert
         _ = result.HasChildren
@@ -346,9 +346,8 @@ public partial class DependencyFinderTests
     }
 
     /// <summary>
-    /// A regular expression representing the package <c>Newtonsoft.Json</c>, which is used by the unit tests.
+    /// Gets a regular expression representing the package <c>Newtonsoft.Json</c>, which is used by the unit tests.
     /// </summary>
-    /// <returns>The regular expression.</returns>
     [GeneratedRegex("Newtonsoft\\.Json")]
-    private static partial Regex MatchingProjectsRegex();
+    private static partial Regex MatchingProjectsRegex { get; }
 }


### PR DESCRIPTION
# Pull Request

## Summary

This includes changes to improve the handling of regular expressions in unit tests by converting methods to properties. The most important changes involve modifying the `FilterRegex` and `MatchingProjectsRegex` methods to be properties and updating the relevant test cases accordingly.

Improvements to regular expression handling:

* [`src/UnitTests/NuGetTransitiveDependencyFinder.UnitTests.ConsoleApp/Process/ProgramRunnerUnitTests.cs`](diffhunk://#diff-859b57afdfdd5c40a9e56cbf1a49b66c88b8e246d86e273414f01b34dca431dbR46-R51): Converted the `FilterRegex` method to a static partial property and updated its usage in the `Run_Called_PerformsExpectedActions` test method. [[1]](diffhunk://#diff-859b57afdfdd5c40a9e56cbf1a49b66c88b8e246d86e273414f01b34dca431dbR46-R51) [[2]](diffhunk://#diff-859b57afdfdd5c40a9e56cbf1a49b66c88b8e246d86e273414f01b34dca431dbL62-R70) [[3]](diffhunk://#diff-859b57afdfdd5c40a9e56cbf1a49b66c88b8e246d86e273414f01b34dca431dbL86-L97)
* [`src/UnitTests/NuGetTransitiveDependencyFinder.UnitTests/ProjectAnalysis/DependencyFinderTests.cs`](diffhunk://#diff-c751ee84f43e85dab8f6ff3a323356551c97144eba7fea30cbd106354e7db8d3L273-R273): Converted the `MatchingProjectsRegex` method to a static partial property and updated its usage in the `Run_WithNoMatchingProjectDependencies_ReturnsEmptyProjects` and `Run_WithMatchingProjectDependenciesButNoTransitiveDependencies_ReturnsEmptyProjects` test methods. [[1]](diffhunk://#diff-c751ee84f43e85dab8f6ff3a323356551c97144eba7fea30cbd106354e7db8d3L273-R273) [[2]](diffhunk://#diff-c751ee84f43e85dab8f6ff3a323356551c97144eba7fea30cbd106354e7db8d3L341-R352)